### PR TITLE
Added the support for primary key

### DIFF
--- a/internal/provider/primarykey_resource.go
+++ b/internal/provider/primarykey_resource.go
@@ -1,0 +1,269 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
+)
+
+var _ resource.Resource = &PrimaryKeyResource{}
+var _ resource.ResourceWithImportState = &PrimaryKeyResource{}
+
+func NewPrimaryKeyResource() resource.Resource {
+	return &PrimaryKeyResource{}
+}
+
+type PrimaryKeyResource struct {
+	client   *f5ossdk.F5os
+	teemData *TeemData
+}
+
+type PrimaryKeyResourceModel struct {
+	Id          types.String `tfsdk:"id"`
+	Passphrase  types.String `tfsdk:"passphrase"`
+	Salt        types.String `tfsdk:"salt"`
+	Status      types.String `tfsdk:"status"`
+	Hash        types.String `tfsdk:"hash"`
+	ForceUpdate types.Bool   `tfsdk:"force_update"`
+}
+
+func (r *PrimaryKeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_primarykey"
+}
+
+func (r *PrimaryKeyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manage system primary-key using passphrase and salt on F5OS devices.",
+
+		Attributes: map[string]schema.Attribute{
+			"force_update": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Force update the primary key on F5OS device.",
+			},
+			"status": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Status of primary key operation (e.g., COMPLETE)",
+			},
+			"hash": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Hash of the primary key as returned by the system.",
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Terraform resource ID for primary key. Constant for now.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"passphrase": schema.StringAttribute{
+				Required:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Specifies passphrase for generating primary key.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(), // Optional: forces recreation on change
+				},
+			},
+
+			"salt": schema.StringAttribute{
+				Required:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Specifies salt for generating primary key.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(), // Optional: forces recreation on change
+				},
+			},
+		},
+	}
+}
+
+func (r *PrimaryKeyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Extract and validate the F5OS client from the provider data
+	client, diagnostics := toF5osProvider(req.ProviderData)
+	resp.Diagnostics.Append(diagnostics...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = client
+
+	// Set up telemetry metadata (optional: can be removed if not needed)
+	teemData := &TeemData{
+		ProviderName: "f5os",
+		ResourceName: "f5os_primarykey",
+	}
+	r.teemData = teemData
+}
+
+func (r *PrimaryKeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *PrimaryKeyResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "[CREATE] Creating PrimaryKey resource")
+	primaryKeyReq := getPrimaryKeyConfig(data)
+
+	tflog.Debug(ctx, fmt.Sprintf("PrimaryKey Request Payload: %+v", primaryKeyReq))
+
+	_ = r.client.SendTeem(map[string]any{"teemData": r.teemData})
+
+	// Skip if already present and not forced
+	if !data.ForceUpdate.ValueBool() {
+		existing, err := r.client.GetPrimaryKey()
+		if err == nil && existing.PrimaryKey.State.Status != "" {
+			tflog.Info(ctx, "[CREATE] Skipping creation as primary key exists and force_update is false")
+			r.primaryKeyResourceModelToState(existing, data)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
+		}
+	}
+
+	// Set the key
+	_, err := r.client.SetPrimaryKey(primaryKeyReq)
+	if err != nil {
+		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to create PrimaryKey: %s", err))
+		return
+	}
+
+	// Now get the state from the device and update the Terraform state
+	keyData, err := r.client.GetPrimaryKey()
+	if err != nil {
+		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to fetch state after setting PrimaryKey: %s", err))
+		return
+	}
+
+	r.primaryKeyResourceModelToState(keyData, data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PrimaryKeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *PrimaryKeyResourceModel
+
+	// Load the current state into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "[READ] Reading F5OS Primary Key Configuration")
+
+	// Fetch the primary key state from the device
+	keyData, err := r.client.GetPrimaryKey()
+	if err != nil {
+		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to fetch Primary Key configuration: %s", err))
+		return
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("PrimaryKey Response: %+v", keyData))
+
+	// Update the state model with fetched data
+	r.primaryKeyResourceModelToState(keyData, data)
+
+	// Save back into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PrimaryKeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *PrimaryKeyResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "[UPDATE] Updating Primary Key configuration")
+
+	// Prepare request payload
+	keyReqConfig := getPrimaryKeyConfig(data)
+	tflog.Debug(ctx, fmt.Sprintf("PrimaryKey Update Payload: %+v", keyReqConfig))
+
+	// Send the update to the F5OS system
+	_, err := r.client.SetPrimaryKey(keyReqConfig) // Use SetPrimaryKey as this acts as upsert
+	if err != nil {
+		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to update Primary Key: %s", err))
+		return
+	}
+
+	// Fetch the latest status after update
+	keyData, err := r.client.GetPrimaryKey()
+	if err != nil {
+		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to retrieve Primary Key after update: %s", err))
+		return
+	}
+
+	// Map response to Terraform model
+	r.primaryKeyResourceModelToState(keyData, data)
+
+	// Save new state to Terraform
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PrimaryKeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *PrimaryKeyResourceModel
+
+	// Load the state into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "[DELETE] Attempting to delete F5OS Primary Key (noop)")
+
+	// According to Ansible module, primary key deletion is not supported — return gracefully
+	resp.Diagnostics.AddWarning(
+		"Unsupported Operation",
+		"The primary key cannot be deleted on F5OS devices. This operation will be a no-op.",
+	)
+
+	// Optionally, you could still attempt a reset endpoint if one exists in F5OS APIs
+}
+
+func (r *PrimaryKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func getPrimaryKeyConfig(data *PrimaryKeyResourceModel) *f5ossdk.F5ReqPrimaryKey {
+	passphrase := data.Passphrase.ValueString()
+	salt := data.Salt.ValueString()
+
+	return &f5ossdk.F5ReqPrimaryKey{
+		PrimaryKey: f5ossdk.PrimaryKeyConfig{
+			Passphrase:        passphrase,
+			ConfirmPassphrase: passphrase,
+			Salt:              salt,
+			ConfirmSalt:       salt,
+		},
+	}
+}
+
+func (r *PrimaryKeyResource) primaryKeyResourceModelToState(respData *f5ossdk.F5RespPrimaryKey, data *PrimaryKeyResourceModel) {
+	if respData.PrimaryKey.State.Status != "" {
+		data.Status = types.StringValue(respData.PrimaryKey.State.Status)
+	} else {
+		data.Status = types.StringNull()
+	}
+
+	if respData.PrimaryKey.State.Hash != "" {
+		data.Hash = types.StringValue(respData.PrimaryKey.State.Hash)
+	} else {
+		data.Hash = types.StringNull()
+	}
+
+	data.Passphrase = data.Passphrase
+	data.Salt = data.Salt
+
+	data.Id = types.StringValue("primary-key")
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -206,6 +206,7 @@ func (p *F5osProvider) Resources(ctx context.Context) []func() resource.Resource
 		NewLagResource,
 		NewPartitionCertKeyResource,
 		NewLicenseResource,
+		NewPrimaryKeyResource,
 	}
 }
 

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/f5os.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/f5os.go
@@ -1164,8 +1164,20 @@ func (p *F5os) setPlatformType() ([]byte, error) {
 		bytes01, _ := io.ReadAll(resp.Body)
 		var mymap map[string]interface{}
 		json.Unmarshal(bytes01, &mymap)
-		if len(mymap["openconfig-platform:component"].([]interface{})) > 1 {
-			for _, val := range mymap["openconfig-platform:component"].([]interface{}) {
+		componentRaw, exists := mymap["openconfig-platform:component"]
+		if !exists {
+			f5osLogger.Debug("[setPlatformType]", "Error", "Key 'openconfig-platform:component' not found in response")
+			return nil, fmt.Errorf("missing 'openconfig-platform:component' key in response")
+		}
+
+		componentList, ok := componentRaw.([]interface{})
+		if !ok {
+			f5osLogger.Debug("[setPlatformType]", "Error", "Invalid type for 'openconfig-platform:component'")
+			return nil, fmt.Errorf("invalid type for 'openconfig-platform:component'")
+		}
+
+		if len(componentList) > 1 {
+			for _, val := range componentList {
 				if val.(map[string]interface{})["name"] == "platform" {
 					//check state key present in above response map object
 					if val.(map[string]interface{})["state"].(map[string]interface{})["description"] != nil {

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/partition.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/partition.go
@@ -23,6 +23,7 @@ const (
 	uriVlan          = "/openconfig-vlan:vlans"
 	uriAuth          = "/openconfig-system:system/aaa"
 	uriCreateCertKey = "/openconfig-system:system/aaa/f5-openconfig-aaa-tls:tls/f5-openconfig-aaa-tls:create-self-signed-cert"
+	uriBase          = "/openconfig-system:system"
 )
 
 func (p *F5os) CreatePartition(partitionObj *F5ReqPartitions) ([]byte, error) {
@@ -382,4 +383,61 @@ func (p *F5os) DeleteTlsCertKey(certKeyName string) error {
 	err := p.DeleteRequest(uri)
 
 	return err
+}
+
+func (p *F5os) SetPrimaryKey(config *F5ReqPrimaryKey) ([]byte, error) {
+	url := fmt.Sprintf("%s/aaa/f5-primary-key:primary-key/f5-primary-key:set", uriBase)
+	f5osLogger.Debug("[SetPrimaryKey]", "Request path", hclog.Fmt("%+v", url))
+
+	reqBody, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+	f5osLogger.Debug("[SetPrimaryKey]", "Request Body", hclog.Fmt("%+v", string(reqBody)))
+
+	respData, err := p.PostRequest(url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	f5osLogger.Debug("[SetPrimaryKey]", "Response", hclog.Fmt("%+v", string(respData)))
+
+	return respData, nil
+}
+
+func (p *F5os) GetPrimaryKey() (*F5RespPrimaryKey, error) {
+	url := fmt.Sprintf("%s/aaa/f5-primary-key:primary-key", uriBase)
+	f5osLogger.Debug("[GetPrimaryKey]", "Request URL", hclog.Fmt("%+v", url))
+
+	body, err := p.GetRequest(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp F5RespPrimaryKey
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+
+	f5osLogger.Debug("[GetPrimaryKey]", "Parsed Response", hclog.Fmt("%+v", resp))
+	return &resp, nil
+}
+
+func (p *F5os) UpdatePrimaryKey(req *F5ReqPrimaryKey) ([]byte, error) {
+	url := fmt.Sprintf("%s/aaa/f5-primary-key:primary-key/f5-primary-key:set", uriBase)
+	f5osLogger.Debug("[UpdatePrimaryKey]", "Request path", hclog.Fmt("%+v", url))
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	f5osLogger.Debug("[UpdatePrimaryKey]", "Body", hclog.Fmt("%+v", string(body)))
+
+	respData, err := p.PostRequest(url, body) // Use POST instead of PATCH as per your API spec
+	if err != nil {
+		return nil, err
+	}
+
+	f5osLogger.Debug("[UpdatePrimaryKey]", "Response", hclog.Fmt("%+v", string(respData)))
+	return respData, nil
 }

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/structs_partition.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/structs_partition.go
@@ -401,3 +401,31 @@ type TlsCertKey struct {
 	ConfirmKeyPassphrase   string `json:"f5-openconfig-aaa-tls:confirm-key-passphrase,omitempty"`
 	StoreTls               bool   `json:"f5-openconfig-aaa-tls:store-tls,omitempty"`
 }
+
+type F5ReqPrimaryKey struct {
+	PrimaryKey PrimaryKeyConfig `json:"f5-primary-key:set"`
+}
+
+type PrimaryKeyConfig struct {
+	Passphrase        string `json:"f5-primary-key:passphrase"`
+	ConfirmPassphrase string `json:"f5-primary-key:confirm-passphrase"`
+	Salt              string `json:"f5-primary-key:salt"`
+	ConfirmSalt       string `json:"f5-primary-key:confirm-salt"`
+}
+
+type F5RespPrimaryKey struct {
+	PrimaryKey struct {
+		State struct {
+			Hash   string `json:"f5-primary-key:hash"`
+			Status string `json:"f5-primary-key:status"`
+		} `json:"f5-primary-key:state"`
+	} `json:"f5-primary-key:primary-key"`
+}
+
+type PrimaryKeyState struct {
+	State PrimaryKeyStatus `json:"state"`
+}
+
+type PrimaryKeyStatus struct {
+	Status string `json:"status"`
+}


### PR DESCRIPTION
Tested with the below configuration:

sample snippet config:
resource "f5os_primarykey" "default" {
  passphrase    = "test-pass"
  salt          = "test-salt"
  force_update  = true
}

Terraform will perform the following actions:

  # f5os_primarykey.default is tainted, so must be replaced
-/+ resource "f5os_primarykey" "default" {
      + hash         = (known after apply)
      ~ id           = "primary-key" -> (known after apply)
      + passphrase   = (sensitive value)
      + salt         = (sensitive value)
      + status       = (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

f5os_primarykey.default: Destroying... [id=primary-key]
f5os_primarykey.default: Destruction complete after 0s
f5os_primarykey.default: Creating...
f5os_primarykey.default: Creation complete after 2s [id=primary-key]
╷
│ Warning: Unsupported Operation
│
│ The primary key cannot be deleted on F5OS devices. This operation will be a no-op.
╵

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.