### PR TITLE
Release v1.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,12 @@ cover.out
 *.goback
 .agents
 reports/
+coverage_report.txt
+AGENTS.md
+*schemadiff
+!schemadiff/
+
+.secure_files/
 
 website/vendor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,59 @@
-## 1.5.1 (Unreleased)
+## 1.12.0 (Unreleased)
+
+BREAKING CHANGES:
+FEATURES:
+BUG FIXES:
+IMPROVEMENTS:
+
+## 1.11.1
+
+FEATURES:
+* `f5os_auth`: Added `password_policy` support for managing password policy configuration
+* `schemadiff`: New tool to diff and report on schema changes between F5OS versions
+* CI/CD: Added support for scheduled releases
+
+BUG FIXES:
+* `f5os_system`: Only manage optional system settings that are explicitly configured
+* `f5os_system`: Prevent panic on nil SshdIdleTimeout type assertion during state read
+* `f5os_dns`: Read method now properly refreshes state from device
+* `f5os_dns`: Delete preserves device config instead of incorrectly removing entries
+* `f5os_dns`: Delete stale entries on update before patching
+* `f5os_dns`: Fix null search domain entry handling
+* `f5os_dns`: Fix null read response handling
+* `f5os_tenant`: Deployment file now properly mapped in Read/state refresh
+* `f5os_tenant`: Type attribute now properly mapped in Read/state refresh
+* `f5os_tenant`: VLANs now properly mapped in Read/state refresh
+* `f5os_tenant_image`: Fix panic on nil map during importWait
+* `f5os_tenant_image`: Read/Import now preserves all config attributes in state
+* `f5os_tenant_image`: GetImage error no longer silently swallowed during Create
+* `f5os_tenant_image`: Fix broken timeout calculation for upload path
+* `f5os_tenant_image`: Add conflict validator between upload_from_path and remote_path
+* `f5os_tenant_image`: Update is no longer a silent no-op
+* `f5os_tenant_image`: Fix Remote Import insecure attribute handling
+* `f5os_tenant_image`: Fix protocol, remote_user, remote_password, and remote_port properties
+* `f5os_ntp_server`: Fix duplicate NTPServerModel type definition
+* `f5os_ntp_server`: CreateNTPServerPayload no longer drops key_id=0 due to omitempty
+* `f5os_ntp_server`: Added Terraform import support
+* `f5os_ntp_server`: Fix ntp_service and ntp_authentication not being written to device
+* `f5os_primarykey`: Fix force_update=false skip logic that never triggered
+* `f5os_primarykey`: Fix SDK JSON deserialization bug causing empty status
+* `f5os_primarykey`: Stabilize post-apply refresh for async primary key migration
+* `f5os_user`: Role update now removes old role assignment, eliminating state drift
+* `f5os_user`: Fix revert of role GID changes during delete
+* `f5os_auth`: Fix auth_order not populating during import
+* `f5os_auth`: Fix SetRoleConfig failure
+* `f5os_auth`: Fix restore of original auth_order during delete
+* `f5os_auth`: Fix device role filtering
+* `f5os_auth`: Query auth resource after create/update for accurate state
+* `f5os_auth`: Fix JSON parsing on F5OS 1.8.3
+* `f5os_snmp`: Delete now properly resets MIB fields
+
+IMPROVEMENTS:
+* Added unit and acceptance tests for partition_change_password resource
+* Added configurable PollInterval to f5osclient, reducing unit test runtime from ~24 minutes to ~7 minutes
+* Documentation updates
+
+## 1.5.1
 
 BREAKING CHANGES:
 FEATURES:

--- a/docs/resources/auth.md
+++ b/docs/resources/auth.md
@@ -3,12 +3,15 @@
 page_title: "f5os_auth Resource - terraform-provider-f5os"
 subcategory: ""
 description: |-
-  Manage AAA authentication on F5OS. Includes authentication method order and role GID mappings.
+  Manage AAA authentication on F5OS. Includes authentication method order, role GID mappings, and password policy.
+  ~> NOTE: Running terraform destroy will restore the original authentication order and revert any role GID changes made by this resource.
 ---
 
 # f5os_auth (Resource)
 
-Manage AAA authentication on F5OS. Includes authentication method order and role GID mappings.
+Manage AAA authentication on F5OS. Includes authentication method order, role GID mappings, and password policy.
+
+~> **NOTE:** Running `terraform destroy` will restore the original authentication order and revert any role GID changes made by this resource.
 
 ## Example Usage
 
@@ -21,6 +24,18 @@ resource "f5os_auth" "aaa" {
     { rolename = "admin", remote_gid = 9000 },
     { rolename = "operator", remote_gid = 9001 },
   ]
+
+  password_policy = {
+    min_length         = 8
+    required_numeric   = 1
+    required_uppercase = 1
+    required_lowercase = 1
+    required_special   = 1
+    reject_username    = true
+    max_login_failures = 5
+    unlock_time        = 300
+    max_age            = 90
+  }
 }
 ```
 
@@ -30,7 +45,7 @@ resource "f5os_auth" "aaa" {
 ### Optional
 
 - `auth_order` (List of String) Ordered list of authentication methods. Allowed values: local, radius, tacacs, ldap.
-- `password_policy` (Attributes) Password policy settings (note: device enforces final policy). (see [below for nested schema](#nestedatt--password_policy))
+- `password_policy` (Attributes) Password policy settings. Only fields you specify are managed; unspecified fields are left at device defaults. (see [below for nested schema](#nestedatt--password_policy))
 - `remote_roles` (Attributes Set) Remote role mappings. Configure role GID (and optionally LDAP group association). (see [below for nested schema](#nestedatt--remote_roles))
 
 ### Read-Only
@@ -42,17 +57,23 @@ resource "f5os_auth" "aaa" {
 
 Optional:
 
-- `allow_consecutive` (Boolean)
-- `allow_username` (Boolean)
-- `history` (Number)
-- `max_age_days` (Number)
-- `max_length` (Number)
-- `min_classes` (Number)
-- `min_length` (Number)
-- `require_digit` (Boolean)
-- `require_lower` (Boolean)
-- `require_special` (Boolean)
-- `require_upper` (Boolean)
+- `apply_to_root` (Boolean) Apply password restrictions to root accounts.
+- `max_age` (Number) Password max age in days (0 = never expires).
+- `max_class_repeat` (Number) Max repeating chars of any class allowed. Only supported on F5OS >= v1.7.
+- `max_letter_repeat` (Number) Max repeating lowercase letters allowed. Only supported on F5OS >= v1.7.
+- `max_login_failures` (Number) Failed login attempts before lockout.
+- `max_sequence_repeat` (Number) Max repeating letters/digits allowed. Only supported on F5OS >= v1.7.
+- `min_length` (Number) Minimum password length.
+- `reject_username` (Boolean) Reject passwords containing the username.
+- `required_differences` (Number) Characters that must differ from previous password.
+- `required_lowercase` (Number) Required lowercase character count.
+- `required_numeric` (Number) Required numeric digit count.
+- `required_special` (Number) Required special character count.
+- `required_uppercase` (Number) Required uppercase character count.
+- `retries` (Number) Password entry retries before failure.
+- `root_lockout` (Boolean) Enable lockout of root accounts.
+- `root_unlock_time` (Number) Root account unlock time in seconds.
+- `unlock_time` (Number) Account unlock time in seconds (0 = manual).
 
 
 <a id="nestedatt--remote_roles"></a>
@@ -67,4 +88,11 @@ Optional:
 - `ldap_group` (String)
 - `remote_gid` (Number)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Auth resource can be imported using a fixed identifier.
+terraform import f5os_auth.example auth
+```

--- a/docs/resources/dns.md
+++ b/docs/resources/dns.md
@@ -4,14 +4,17 @@ page_title: "f5os_dns Resource - terraform-provider-f5os"
 subcategory: ""
 description: |-
   Resource used to configure DNS settings (servers and domains) on F5OS systems (VELOS or rSeries).
-  ~> NOTE: The f5os_dns resource updates DNS servers and search domains on the F5OS platforms using Open API
+  ~> NOTE: The f5os_dns resource updates DNS servers and search domains on the F5OS platforms using Open API. When updating, any servers or domains removed from the configuration are also deleted from the device before the new values are applied.
+  ~> IMPORTANT: Running terraform destroy will remove this resource from Terraform state but will not delete the DNS configuration from the device. DNS is a critical system service and removing it could make the device unreachable.
 ---
 
 # f5os_dns (Resource)
 
 Resource used to configure DNS settings (servers and domains) on F5OS systems (VELOS or rSeries).
 
-~> **NOTE:** The `f5os_dns` resource updates DNS servers and search domains on the F5OS platforms using Open API
+~> **NOTE:** The `f5os_dns` resource updates DNS servers and search domains on the F5OS platforms using Open API. When updating, any servers or domains removed from the configuration are also deleted from the device before the new values are applied.
+
+~> **IMPORTANT:** Running `terraform destroy` will remove this resource from Terraform state but will **not** delete the DNS configuration from the device. DNS is a critical system service and removing it could make the device unreachable.
 
 ## Example Usage
 

--- a/docs/resources/ntp_server.md
+++ b/docs/resources/ntp_server.md
@@ -42,4 +42,11 @@ resource "f5os_ntp_server" "test" {
 
 - `id` (String) Terraform synthetic ID (server address).
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# NTP server can be imported by specifying the server address.
+terraform import f5os_ntp_server.example 10.20.30.40
+```

--- a/docs/resources/snmp.md
+++ b/docs/resources/snmp.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Resource used to manage SNMP configuration (Communities, Users, Targets, and MIB settings) on F5OS systems (VELOS or rSeries).
   ~> NOTE: The f5os_snmp resource manages SNMP settings on F5OS platforms using Open API. Due to API restrictions, passwords cannot be retrieved which may lead to Terraform detecting changes on every plan.
+  ~> NOTE: Running terraform destroy will reset MIB fields (sysContact, sysLocation, sysName) to their defaults and remove the resource from Terraform state.
 ---
 
 # f5os_snmp (Resource)
@@ -12,6 +13,8 @@ description: |-
 Resource used to manage SNMP configuration (Communities, Users, Targets, and MIB settings) on F5OS systems (VELOS or rSeries).
 
 ~> **NOTE:** The `f5os_snmp` resource manages SNMP settings on F5OS platforms using Open API. Due to API restrictions, passwords cannot be retrieved which may lead to Terraform detecting changes on every plan.
+
+~> **NOTE:** Running `terraform destroy` will reset MIB fields (sysContact, sysLocation, sysName) to their defaults and remove the resource from Terraform state.
 
 ## Example Usage
 

--- a/docs/resources/tenant_image.md
+++ b/docs/resources/tenant_image.md
@@ -13,13 +13,28 @@ Resource used for Manage F5OS tenant images
 ## Example Usage
 
 ```terraform
-# Resource for tenant image copy
+# Import a tenant image from a remote HTTPS server
 resource "f5os_tenant_image" "test" {
   image_name  = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
   remote_host = "xxxxx"
   remote_path = "v17.1.0/daily/current/VM"
   local_path  = "images" ## for velos partition/rSeries appliance this path should be `images`/`images/tenant` respectively
+  protocol    = "https"  ## supported values: scp, sftp, https
+  insecure    = true     ## skip TLS certificate verification on the remote host
   timeout     = 360
+}
+
+# Import a tenant image via SCP with credentials
+resource "f5os_tenant_image" "scp_example" {
+  image_name      = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = "xxxxx"
+  remote_path     = "v17.1.0/daily/current/VM"
+  local_path      = "images/tenant"
+  protocol        = "scp"
+  remote_user     = "imageuser"
+  remote_password = "imagepass"
+  remote_port     = 22
+  timeout         = 600
 }
 ```
 
@@ -32,8 +47,10 @@ resource "f5os_tenant_image" "test" {
 
 ### Optional
 
+- `insecure` (Boolean) When set to `true`, the image transfer skips TLS certificate verification on the remote host.
+Useful when importing images over HTTPS from servers with self-signed certificates.
 - `local_path` (String) The path on the F5OS where the the tenant image is to be imported to.
-- `protocol` (String) Protocol for image transfer.
+- `protocol` (String) Protocol for image transfer. Supported values: `scp`, `sftp`, `https`.
 - `remote_host` (String) The hostname or IP address of the remote server on which the tenant image is stored.
 The server must make the image accessible via the specified protocol.
 - `remote_password` (String, Sensitive) Password for the user on the remote server on which the tenant image is stored.
@@ -49,4 +66,11 @@ If the port is not provided, a default port for the selected protocol is used.
 - `id` (String) Example identifier
 - `status` (String) Status of Imported Image
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Tenant image can be imported by specifying the image name.
+terraform import f5os_tenant_image.example BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle
+```

--- a/examples/resources/f5os_auth/import.sh
+++ b/examples/resources/f5os_auth/import.sh
@@ -1,0 +1,2 @@
+# Auth resource can be imported using a fixed identifier.
+terraform import f5os_auth.example auth

--- a/examples/resources/f5os_auth/resource.tf
+++ b/examples/resources/f5os_auth/resource.tf
@@ -6,4 +6,16 @@ resource "f5os_auth" "aaa" {
     { rolename = "admin", remote_gid = 9000 },
     { rolename = "operator", remote_gid = 9001 },
   ]
+
+  password_policy = {
+    min_length         = 8
+    required_numeric   = 1
+    required_uppercase = 1
+    required_lowercase = 1
+    required_special   = 1
+    reject_username    = true
+    max_login_failures = 5
+    unlock_time        = 300
+    max_age            = 90
+  }
 }

--- a/examples/resources/f5os_ntp_server/import.sh
+++ b/examples/resources/f5os_ntp_server/import.sh
@@ -1,0 +1,2 @@
+# NTP server can be imported by specifying the server address.
+terraform import f5os_ntp_server.example 10.20.30.40

--- a/examples/resources/f5os_tenant_image/import.sh
+++ b/examples/resources/f5os_tenant_image/import.sh
@@ -1,0 +1,2 @@
+# Tenant image can be imported by specifying the image name.
+terraform import f5os_tenant_image.example BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle

--- a/examples/resources/f5os_tenant_image/resource.tf
+++ b/examples/resources/f5os_tenant_image/resource.tf
@@ -1,8 +1,23 @@
-# Resource for tenant image copy
+# Import a tenant image from a remote HTTPS server
 resource "f5os_tenant_image" "test" {
   image_name  = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
   remote_host = "xxxxx"
   remote_path = "v17.1.0/daily/current/VM"
   local_path  = "images" ## for velos partition/rSeries appliance this path should be `images`/`images/tenant` respectively
+  protocol    = "https"  ## supported values: scp, sftp, https
+  insecure    = true     ## skip TLS certificate verification on the remote host
   timeout     = 360
+}
+
+# Import a tenant image via SCP with credentials
+resource "f5os_tenant_image" "scp_example" {
+  image_name      = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = "xxxxx"
+  remote_path     = "v17.1.0/daily/current/VM"
+  local_path      = "images/tenant"
+  protocol        = "scp"
+  remote_user     = "imageuser"
+  remote_password = "imagepass"
+  remote_port     = 22
+  timeout         = 600
 }

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -1,6 +1,25 @@
 package provider
 
-import "net"
+import (
+	"net"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// platformVersionAtLeast returns true if the device platform version is >= the
+// given minimum version. Both the platform version (e.g., "1.8.3-23453") and
+// the minimum (e.g., "v1.7") are normalized to semver for comparison.
+// Returns false if the platform version is empty or not valid semver.
+func platformVersionAtLeast(platformVersion, minimum string) bool {
+	if platformVersion == "" {
+		return false
+	}
+	if !strings.HasPrefix(platformVersion, "v") {
+		platformVersion = "v" + platformVersion
+	}
+	return semver.Compare(semver.MajorMinor(platformVersion), minimum) >= 0
+}
 
 func extractSubnet(cidr string) (int, string, error) {
 	ip, ipNet, err := net.ParseCIDR(cidr)

--- a/internal/provider/dns_resource.go
+++ b/internal/provider/dns_resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -49,7 +48,9 @@ func (r *DNSResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 func (r *DNSResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Resource used to configure DNS settings (servers and domains) on F5OS systems (VELOS or rSeries).\n\n" +
-			"~> **NOTE:** The `f5os_dns` resource updates DNS servers and search domains on the F5OS platforms using Open API",
+			"~> **NOTE:** The `f5os_dns` resource updates DNS servers and search domains on the F5OS platforms using Open API. " +
+			"When updating, any servers or domains removed from the configuration are also deleted from the device before the new values are applied.\n\n" +
+			"~> **IMPORTANT:** Running `terraform destroy` will remove this resource from Terraform state but will **not** delete the DNS configuration from the device. DNS is a critical system service and removing it could make the device unreachable.",
 		Attributes: map[string]schema.Attribute{
 			"dns_servers": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -88,13 +89,19 @@ func (r *DNSResource) Configure(_ context.Context, req resource.ConfigureRequest
 	r.client = client
 }
 
-// extractStringList safely extracts a string list from a types.List
+// extractStringList safely extracts a string list from a types.List.
+// Always returns a non-nil slice so callers never send JSON null to the
+// API and types.ListValueFrom never produces a null Terraform list.
 func extractStringList(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
 	var result []string
 	var diags diag.Diagnostics
 
 	if !list.IsNull() && !list.IsUnknown() {
 		diags = list.ElementsAs(ctx, &result, false)
+	}
+
+	if result == nil {
+		result = []string{}
 	}
 
 	return result, diags
@@ -144,6 +151,42 @@ func (r *DNSResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	// Read the current device state so we can remove pre-existing entries
+	// that are not in the Terraform config. The F5OS DNS PATCH API is
+	// additive — it merges with existing config rather than replacing it.
+	// Without this step, pre-existing servers/domains would persist on the
+	// device and cause drift on the next refresh.
+	existing, err := r.client.ReadDNSConfig()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"DNS Configuration Error",
+			fmt.Sprintf("Failed to read existing DNS configuration: %s", err),
+		)
+		return
+	}
+
+	var existingServers, existingDomains []string
+	for _, s := range existing.DNS.Servers.Server {
+		existingServers = append(existingServers, s.Address)
+	}
+	existingDomains = append(existingDomains, existing.DNS.Config.Search...)
+
+	staleServers := removedEntries(existingServers, dnsServers)
+	staleDomains := removedEntries(existingDomains, dnsDomains)
+	if len(staleServers) > 0 || len(staleDomains) > 0 {
+		tflog.Debug(ctx, "Removing pre-existing DNS entries not in config", map[string]interface{}{
+			"stale_servers": staleServers,
+			"stale_domains": staleDomains,
+		})
+		if err := r.client.DeleteDNSConfig(staleServers, staleDomains); err != nil {
+			resp.Diagnostics.AddError(
+				"DNS Configuration Error",
+				fmt.Sprintf("Failed to remove pre-existing DNS entries: %s", err),
+			)
+			return
+		}
+	}
+
 	// Call client to PATCH DNS config
 	if err := r.client.PatchDNSConfig(dnsServers, dnsDomains); err != nil {
 		resp.Diagnostics.AddError(
@@ -156,6 +199,17 @@ func (r *DNSResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// Compute resource ID based on configuration
 	resourceID := computeResourceID(dnsServers, dnsDomains)
 	plan.Id = types.StringValue(resourceID)
+
+	// Ensure dns_domains is never null in state — when omitted from the
+	// HCL config, the plan value is null, but Computed attributes must
+	// be known after apply. Set it to an empty list.
+	if plan.DNSDomains.IsNull() || plan.DNSDomains.IsUnknown() {
+		plan.DNSDomains, diags = types.ListValueFrom(ctx, types.StringType, dnsDomains)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
 
 	tflog.Debug(ctx, "DNS configuration created successfully", map[string]interface{}{
 		"servers": dnsServers,
@@ -180,25 +234,11 @@ func (r *DNSResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	tflog.Info(ctx, "Reading DNS configuration from F5OS")
 
 	// Fetch DNS config from F5OS API
-	rawResp, err := r.client.GetRequest("/openconfig-system:system/dns")
+	config, err := r.client.ReadDNSConfig()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"DNS Read Error",
 			fmt.Sprintf("Failed to fetch DNS configuration: %s", err),
-		)
-		return
-	}
-
-	tflog.Debug(ctx, "Received DNS configuration", map[string]interface{}{
-		"response": string(rawResp),
-	})
-
-	// Parse the response
-	var config f5os.DNSConfigPayload
-	if err := json.Unmarshal(rawResp, &config); err != nil {
-		resp.Diagnostics.AddError(
-			"DNS Parse Error",
-			fmt.Sprintf("Failed to parse DNS configuration: %s\nRaw response: %s", err, string(rawResp)),
 		)
 		return
 	}
@@ -211,31 +251,33 @@ func (r *DNSResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		config.DNS.Config.Search = []string{}
 	}
 
-	// Extract values
-	var servers, domains []string
+	// Extract values — use non-nil empty slices so types.ListValueFrom
+	// always produces an empty list rather than a null Terraform value.
+	servers := make([]string, 0, len(config.DNS.Servers.Server))
 	for _, s := range config.DNS.Servers.Server {
 		servers = append(servers, s.Address)
 	}
+	domains := make([]string, 0, len(config.DNS.Config.Search))
 	domains = append(domains, config.DNS.Config.Search...)
 
 	// Set Terraform types
-	_, diags := types.ListValueFrom(ctx, types.StringType, servers)
+	serversTF, diags := types.ListValueFrom(ctx, types.StringType, servers)
 	resp.Diagnostics.Append(diags...)
 
-	_, diags = types.ListValueFrom(ctx, types.StringType, domains)
+	domainsTF, diags := types.ListValueFrom(ctx, types.StringType, domains)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Update state
-	// state.DNSServers = serversTF
-	// state.DNSDomains = domainsTF
+	// Update state from device
+	state.DNSServers = serversTF
+	state.DNSDomains = domainsTF
 
-	// Compute resource ID based on current configuration
-	// resourceID := computeResourceID(servers, domains)
-	// state.Id = types.StringValue(resourceID)
+	// Recompute resource ID based on current device configuration
+	resourceID := computeResourceID(servers, domains)
+	state.Id = types.StringValue(resourceID)
 
 	tflog.Debug(ctx, "Setting DNS state", map[string]interface{}{
 		"servers": servers,
@@ -249,27 +291,44 @@ func (r *DNSResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 // Update updates the resource and sets the updated Terraform state
 func (r *DNSResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan DNSResourceModel
+	var plan, prior DNSResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	tflog.Info(ctx, "Updating DNS configuration")
 
-	// Extract DNS Servers and Domains
+	// Extract planned (new) values
 	dnsServers, diags := extractStringList(ctx, plan.DNSServers)
 	resp.Diagnostics.Append(diags...)
 
 	dnsDomains, diags := extractStringList(ctx, plan.DNSDomains)
 	resp.Diagnostics.Append(diags...)
 
+	// Extract prior (old) values
+	oldServers, diags := extractStringList(ctx, prior.DNSServers)
+	resp.Diagnostics.Append(diags...)
+
+	oldDomains, diags := extractStringList(ctx, prior.DNSDomains)
+	resp.Diagnostics.Append(diags...)
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Call PATCH operation via client SDK
+	// Delete servers and domains that were removed from the config
+	removed := removedEntries(oldServers, dnsServers)
+	removedDoms := removedEntries(oldDomains, dnsDomains)
+	if err := r.client.DeleteDNSConfig(removed, removedDoms); err != nil {
+		resp.Diagnostics.AddError("DNS Update Error",
+			fmt.Sprintf("Failed to remove stale DNS entries: %s", err))
+		return
+	}
+
+	// Patch remaining / newly added entries
 	if err := r.client.PatchDNSConfig(dnsServers, dnsDomains); err != nil {
 		resp.Diagnostics.AddError(
 			"DNS Update Error",
@@ -282,6 +341,15 @@ func (r *DNSResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	resourceID := computeResourceID(dnsServers, dnsDomains)
 	plan.Id = types.StringValue(resourceID)
 
+	// Ensure dns_domains is never null/unknown in state after Update.
+	if plan.DNSDomains.IsNull() || plan.DNSDomains.IsUnknown() {
+		plan.DNSDomains, diags = types.ListValueFrom(ctx, types.StringType, dnsDomains)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	tflog.Debug(ctx, "DNS configuration updated successfully", map[string]interface{}{
 		"servers": dnsServers,
 		"domains": dnsDomains,
@@ -291,51 +359,30 @@ func (r *DNSResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-// Delete deletes the resource and removes the Terraform state
+// removedEntries returns elements present in old but absent from new.
+func removedEntries(old, new []string) []string {
+	set := make(map[string]struct{}, len(new))
+	for _, v := range new {
+		set[v] = struct{}{}
+	}
+	var removed []string
+	for _, v := range old {
+		if _, ok := set[v]; !ok {
+			removed = append(removed, v)
+		}
+	}
+	return removed
+}
+
+// Delete removes the DNS resource from Terraform state without modifying the
+// device. DNS is a singleton system setting — removing the managed entries
+// would break name resolution and could make the device unreachable.
 func (r *DNSResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var state DNSResourceModel
+	tflog.Info(ctx, "Removing DNS resource from Terraform state (device configuration is preserved)")
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	tflog.Info(ctx, "Deleting DNS configuration")
-
-	// Extract DNS servers and domains
-	dnsServers, diags := extractStringList(ctx, state.DNSServers)
-	resp.Diagnostics.Append(diags...)
-
-	dnsDomains, diags := extractStringList(ctx, state.DNSDomains)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Delete DNS servers individually
-	for _, server := range dnsServers {
-		if err := r.client.DeleteDNSServer(server); err != nil {
-			resp.Diagnostics.AddWarning(
-				"DNS Server Deletion Warning",
-				fmt.Sprintf("Failed to delete DNS server [%s]: %s", server, err),
-			)
-		}
-	}
-
-	// Delete DNS search domains individually
-	for _, domain := range dnsDomains {
-		if err := r.client.DeleteSearchDomain(domain); err != nil {
-			resp.Diagnostics.AddWarning(
-				"DNS Domain Deletion Warning",
-				fmt.Sprintf("Failed to delete DNS domain [%s]: %s", domain, err),
-			)
-		}
-	}
-
-	tflog.Debug(ctx, "DNS configuration deleted", map[string]interface{}{
-		"servers": dnsServers,
-		"domains": dnsDomains,
-		"id":      state.Id.ValueString(),
-	})
+	resp.Diagnostics.AddWarning(
+		"DNS Configuration Preserved",
+		"The DNS resource has been removed from Terraform state, but the DNS configuration on the device has been left intact. "+
+			"To modify DNS settings, re-import the resource or create a new f5os_dns resource.",
+	)
 }

--- a/internal/provider/dns_resource_test.go
+++ b/internal/provider/dns_resource_test.go
@@ -1,54 +1,49 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
 
-// -- Structs used in DNS config patch payload --
-
-type DNSServer struct {
-	Address string `json:"address"`
-}
-
-type DNSConfigServers struct {
-	Server []DNSServer `json:"server"`
-}
-
-type DNSConfigSearch struct {
-	Search []string `json:"search"`
-}
-
-type DNSConfig struct {
-	Servers DNSConfigServers `json:"servers"`
-	Config  DNSConfigSearch  `json:"config"`
-}
-
-type DNSConfigPayload struct {
-	DNS DNSConfig `json:"openconfig-system:dns"`
-}
-
-// -- Mock F5os struct --
-
-type F5os struct {
-	UriRoot string
-}
+// DNS payload types are defined in f5osclient (structs_partition.go).
+// Alias them here so test helpers can unmarshal mock request bodies
+// without duplicating the struct definitions.
+type (
+	DNSConfigPayload = f5ossdk.DNSConfigPayload
+	DNSConfig        = f5ossdk.DNSConfig
+	DNSConfigServers = f5ossdk.DNSConfigServers
+	DNSConfigSearch  = f5ossdk.DNSConfigSearch
+	DNSServer        = f5ossdk.DNSServer
+)
 
 // -- Acceptance Test (requires live F5OS device) --
 
 func TestAccF5osDNSResource(t *testing.T) {
+	expectedID := computeResourceID([]string{"8.8.8.8"}, []string{"internal.domain"})
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccF5osDNSConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
-					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "internal.domain"), // fix this index
-					resource.TestCheckResourceAttr("f5os_dns.test", "id", "dns"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "internal.domain"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "id", expectedID),
 				),
 			},
 		},
@@ -118,3 +113,1354 @@ resource "f5os_dns" "test" {
   dns_servers = ["8.8.8.8"]
   dns_domains = ["internal.domain"]
 }`
+
+// ---------------------------------------------------------------------------
+// Shared mock setup for DNS unit tests
+// ---------------------------------------------------------------------------
+
+// dnsMockState holds mutable mock-server state shared across handlers.
+type dnsMockState struct {
+	servers     []string
+	domains     []string
+	deleteCount int
+}
+
+// setupDNSMock registers all the standard mock handlers needed for DNS
+// unit tests and returns a pointer to the shared state so the test can
+// mutate the device-side data between steps. The caller is responsible
+// for calling teardown() when the test completes.
+func setupDNSMock(t *testing.T, initialServers []string, initialDomains []string) *dnsMockState {
+	t.Helper()
+	testAccPreUnitCheck(t)
+
+	st := &dnsMockState{
+		servers: initialServers,
+		domains: initialDomains,
+	}
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/dns", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			// Build dynamic response from current mock state
+			var serverJSON string
+			for i, s := range st.servers {
+				if i > 0 {
+					serverJSON += ","
+				}
+				serverJSON += `{"address":"` + s + `"}`
+			}
+			var domainJSON string
+			for i, d := range st.domains {
+				if i > 0 {
+					domainJSON += ","
+				}
+				domainJSON += `"` + d + `"`
+			}
+			resp := `{"openconfig-system:dns":{"servers":{"server":[` +
+				serverJSON + `]},"config":{"search":[` + domainJSON + `]}}}`
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(resp))
+		case "PATCH":
+			var p DNSConfigPayload
+			if err := json.NewDecoder(r.Body).Decode(&p); err == nil {
+				st.servers = nil
+				for _, s := range p.DNS.Servers.Server {
+					st.servers = append(st.servers, s.Address)
+				}
+				st.domains = p.DNS.Config.Search
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "DELETE":
+			st.deleteCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("Unexpected HTTP method on /dns: %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	// DELETE for individual servers: /restconf/data/openconfig-system:system/dns/servers/server=<addr>
+	mux.HandleFunc("/restconf/data/openconfig-system:system/dns/servers/", func(w http.ResponseWriter, r *http.Request) {
+		// Parse address from path (.../server=<addr>)
+		parts := strings.SplitN(r.URL.Path, "server=", 2)
+		if len(parts) == 2 {
+			addr := parts[1]
+			var kept []string
+			for _, s := range st.servers {
+				if s != addr {
+					kept = append(kept, s)
+				}
+			}
+			st.servers = kept
+		}
+		st.deleteCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	// DELETE for individual domains: /restconf/data/openconfig-system:system/dns/config/search=<domain>
+	mux.HandleFunc("/restconf/data/openconfig-system:system/dns/config/", func(w http.ResponseWriter, r *http.Request) {
+		// Parse domain from path (.../search=<domain>)
+		parts := strings.SplitN(r.URL.Path, "search=", 2)
+		if len(parts) == 2 {
+			dom := parts[1]
+			var kept []string
+			for _, d := range st.domains {
+				if d != dom {
+					kept = append(kept, d)
+				}
+			}
+			st.domains = kept
+		}
+		st.deleteCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	return st
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for Read method fix (state refresh from device)
+// ---------------------------------------------------------------------------
+
+// TestUnitDNSReadRefreshesServersFromDevice verifies that Read populates
+// dns_servers from the device API response rather than preserving stale
+// prior state. Before the fix, Read fetched the data but never wrote it
+// back to state (the assignment was commented out).
+func TestUnitDNSReadRefreshesServersFromDevice(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"internal.domain"})
+	defer teardown()
+
+	expectedID := computeResourceID([]string{"8.8.8.8"}, []string{"internal.domain"})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with 8.8.8.8
+			{
+				Config: testUnitDNSOneServer,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "internal.domain"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "id", expectedID),
+				),
+			},
+			// Step 2: Simulate out-of-band change — device now returns 1.1.1.1
+			// but HCL still says 8.8.8.8. Read must detect the drift and
+			// the plan must show a diff. We apply the config with 1.1.1.1
+			// to match the device and confirm the state is correct.
+			{
+				PreConfig: func() {
+					st.servers = []string{"1.1.1.1"}
+					st.domains = []string{"changed.domain"}
+				},
+				Config: testUnitDNSOneServerChanged,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "changed.domain"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSReadRefreshesDomainsFromDevice verifies that Read populates
+// dns_domains from the device API response. Step 1 creates with one domain,
+// then the mock changes the domain out-of-band before Step 2's Read. Step 2
+// supplies the new domain in HCL so the plan converges.
+func TestUnitDNSReadRefreshesDomainsFromDevice(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"original.domain"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with one domain
+			{
+				Config: testUnitDNSOriginalDomainConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "original.domain"),
+				),
+			},
+			// Step 2: Device changes domain out-of-band. Read must detect
+			// the new domain from the device. Config matches the new value.
+			{
+				PreConfig: func() {
+					st.domains = []string{"surprise.domain"}
+				},
+				Config: testUnitDNSSurpriseDomainConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "surprise.domain"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSReadRecomputesIdFromDevice verifies that the Read method
+// recomputes the resource ID from the actual device state. Before the fix,
+// the ID was never updated during Read, so it could become stale if the
+// device state drifted.
+func TestUnitDNSReadRecomputesIdFromDevice(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"internal.domain"})
+	defer teardown()
+
+	expectedID1 := computeResourceID([]string{"8.8.8.8"}, []string{"internal.domain"})
+	expectedID2 := computeResourceID([]string{"1.1.1.1"}, []string{"new.domain"})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create — ID is computed from servers + domains
+			{
+				Config: testUnitDNSOneServer,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "id", expectedID1),
+				),
+			},
+			// Step 2: Device changes out-of-band. Config matches new device
+			// values. Read must recompute the ID from the new device state.
+			{
+				PreConfig: func() {
+					st.servers = []string{"1.1.1.1"}
+					st.domains = []string{"new.domain"}
+				},
+				Config: testUnitDNSIdRecomputeConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "id", expectedID2),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSReadHandlesEmptyDomains verifies that when the device returns
+// no domains, the Read method writes an empty list to state rather than
+// leaving stale data. Servers are swapped (not emptied) because dns_servers
+// is required by the schema and cannot be zero-length in a valid config.
+func TestUnitDNSReadHandlesEmptyDomains(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"internal.domain"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create normally
+			{
+				Config: testUnitDNSOneServer,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+				),
+			},
+			// Step 2: Device domains are wiped; Read must reflect empty domains.
+			// Servers are changed (not emptied) because dns_servers is required.
+			{
+				PreConfig: func() {
+					st.servers = []string{"9.9.9.9"}
+					st.domains = []string{}
+				},
+				Config: testUnitDNSEmptyAfterWipeConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "9.9.9.9"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSReadMultipleServersAndDomains verifies that Read correctly
+// handles multiple servers and domains from the device response.
+func TestUnitDNSReadMultipleServersAndDomains(t *testing.T) {
+	_ = setupDNSMock(t, []string{"8.8.8.8", "1.1.1.1"}, []string{"foo.local", "bar.local"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitDNSMultiConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.1", "1.1.1.1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "2"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "foo.local"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.1", "bar.local"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for Update method fix (stale entry deletion)
+// ---------------------------------------------------------------------------
+
+// TestUnitDNSUpdateRemovesStaleEntries verifies that shrinking the server
+// or domain list in an Update correctly deletes the removed entries from
+// the device rather than leaving them as stale config.
+func TestUnitDNSUpdateRemovesStaleEntries(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8", "1.1.1.1"}, []string{"foo.local", "bar.local"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with two servers and two domains
+			{
+				Config: testUnitDNSTwoServersConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "2"),
+				),
+			},
+			// Step 2: Shrink to one server and one domain
+			{
+				Config: testUnitDNSOneServerOneDomainConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "foo.local"),
+					// Verify the mock state reflects the removal
+					func(s *terraform.State) error {
+						for _, srv := range st.servers {
+							if srv == "1.1.1.1" {
+								return fmt.Errorf("stale server 1.1.1.1 still in mock state: %v", st.servers)
+							}
+						}
+						for _, dom := range st.domains {
+							if dom == "bar.local" {
+								return fmt.Errorf("stale domain bar.local still in mock state: %v", st.domains)
+							}
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSUpdateAddsEntries verifies that growing the server and domain
+// lists (no removals) works correctly. removedEntries returns empty so
+// DeleteDNSConfig is effectively a no-op, and PatchDNSConfig adds the new
+// entries.
+func TestUnitDNSUpdateAddsEntries(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"foo.local"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with one server and one domain
+			{
+				Config: testUnitDNSGrowStep1Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+				),
+			},
+			// Step 2: Grow to two servers and two domains
+			{
+				Config: testUnitDNSGrowStep2Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.1", "1.1.1.1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "2"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "foo.local"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.1", "bar.local"),
+					// Mock state should contain all entries (none removed)
+					func(s *terraform.State) error {
+						if len(st.servers) != 2 {
+							return fmt.Errorf("expected 2 servers in mock, got %v", st.servers)
+						}
+						if len(st.domains) != 2 {
+							return fmt.Errorf("expected 2 domains in mock, got %v", st.domains)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSUpdateSwapsAllEntries verifies that completely replacing all
+// servers and domains in a single Update works. Every old entry is removed
+// via DeleteDNSConfig, then PatchDNSConfig applies the new entries.
+func TestUnitDNSUpdateSwapsAllEntries(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"old.local"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testUnitDNSSwapStep1Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "old.local"),
+				),
+			},
+			// Step 2: Swap every entry
+			{
+				Config: testUnitDNSSwapStep2Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "9.9.9.9"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "new.local"),
+					// Verify old entries are gone from mock
+					func(s *terraform.State) error {
+						for _, srv := range st.servers {
+							if srv == "8.8.8.8" {
+								return fmt.Errorf("old server 8.8.8.8 still in mock: %v", st.servers)
+							}
+						}
+						for _, dom := range st.domains {
+							if dom == "old.local" {
+								return fmt.Errorf("old domain old.local still in mock: %v", st.domains)
+							}
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// HCL configs for DNS unit tests
+// ---------------------------------------------------------------------------
+
+const testUnitDNSOneServer = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["internal.domain"]
+}
+`
+
+const testUnitDNSOneServerChanged = `
+resource "f5os_dns" "test" {
+  dns_servers = ["1.1.1.1"]
+  dns_domains = ["changed.domain"]
+}
+`
+
+const testUnitDNSOriginalDomainConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["original.domain"]
+}
+`
+
+const testUnitDNSSurpriseDomainConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["surprise.domain"]
+}
+`
+
+const testUnitDNSIdRecomputeConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["1.1.1.1"]
+  dns_domains = ["new.domain"]
+}
+`
+
+const testUnitDNSEmptyAfterWipeConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["9.9.9.9"]
+}
+`
+
+const testUnitDNSMultiConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8", "1.1.1.1"]
+  dns_domains = ["foo.local", "bar.local"]
+}
+`
+
+const testUnitDNSTwoServersConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8", "1.1.1.1"]
+  dns_domains = ["foo.local", "bar.local"]
+}
+`
+
+const testUnitDNSOneServerOneDomainConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["foo.local"]
+}
+`
+
+const testUnitDNSGrowStep1Config = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["foo.local"]
+}
+`
+
+const testUnitDNSGrowStep2Config = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8", "1.1.1.1"]
+  dns_domains = ["foo.local", "bar.local"]
+}
+`
+
+const testUnitDNSSwapStep1Config = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["old.local"]
+}
+`
+
+const testUnitDNSSwapStep2Config = `
+resource "f5os_dns" "test" {
+  dns_servers = ["9.9.9.9"]
+  dns_domains = ["new.local"]
+}
+`
+
+// ---------------------------------------------------------------------------
+// Unit test for Delete no-op behavior
+// ---------------------------------------------------------------------------
+
+// TestUnitDNSDeletePreservesDeviceConfig verifies that Delete removes the
+// resource from Terraform state without making any DELETE API calls to the
+// device. DNS is a singleton system setting — removing managed entries
+// would break name resolution and could make the device unreachable.
+func TestUnitDNSDeletePreservesDeviceConfig(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"internal.domain"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitDNSOneServer,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+				),
+			},
+			{
+				Destroy: true,
+				Config:  testUnitDNSOneServer,
+				Check: func(s *terraform.State) error {
+					if st.deleteCount > 0 {
+						return fmt.Errorf("expected no DELETE calls to device, got %d", st.deleteCount)
+					}
+					if len(st.servers) != 1 || st.servers[0] != "8.8.8.8" {
+						return fmt.Errorf("expected device servers to be preserved as [8.8.8.8], got %v", st.servers)
+					}
+					if len(st.domains) != 1 || st.domains[0] != "internal.domain" {
+						return fmt.Errorf("expected device domains to be preserved as [internal.domain], got %v", st.domains)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test helpers
+// ---------------------------------------------------------------------------
+
+// newDNSClientFromEnv creates a fresh f5osclient session from env vars.
+// Port defaults to 8888 to match the provider.
+func newDNSClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
+
+// testAccCheckDNSServerPresentOnDevice queries the device directly and
+// verifies that the given server address is present in the DNS config.
+// Uses a "contains" check rather than exact match because PatchDNSConfig
+// is additive (PATCH, not PUT).
+func testAccCheckDNSServerPresentOnDevice(server string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newDNSClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		config, err := client.ReadDNSConfig()
+		if err != nil {
+			return fmt.Errorf("ReadDNSConfig failed: %w", err)
+		}
+		for _, srv := range config.DNS.Servers.Server {
+			if srv.Address == server {
+				return nil
+			}
+		}
+		var actual []string
+		for _, srv := range config.DNS.Servers.Server {
+			actual = append(actual, srv.Address)
+		}
+		return fmt.Errorf("server %q not found on device, got %v", server, actual)
+	}
+}
+
+// testAccCheckDNSDomainPresentOnDevice queries the device directly and
+// verifies that the given search domain is present in the DNS config.
+func testAccCheckDNSDomainPresentOnDevice(domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newDNSClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		config, err := client.ReadDNSConfig()
+		if err != nil {
+			return fmt.Errorf("ReadDNSConfig failed: %w", err)
+		}
+		for _, d := range config.DNS.Config.Search {
+			if d == domain {
+				return nil
+			}
+		}
+		return fmt.Errorf("domain %q not found on device, got %v", domain, config.DNS.Config.Search)
+	}
+}
+
+// testAccCheckDNSDestroy verifies that the resource was removed from state.
+// Delete is a no-op on the device (DNS config is preserved), so we only
+// confirm the device is still reachable and DNS config still exists.
+func testAccCheckDNSDestroy(s *terraform.State) error {
+	client, err := newDNSClientFromEnv()
+	if err != nil {
+		return nil // cannot connect — nothing to verify
+	}
+	_, err = client.ReadDNSConfig()
+	if err != nil {
+		return fmt.Errorf("device DNS config should still exist after destroy (no-op), but ReadDNSConfig failed: %s", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for Read method fix (state refresh from device)
+// ---------------------------------------------------------------------------
+
+// TestAccDNSReadRefreshesStateFromDevice is the primary acceptance test for
+// the Read fix. It exercises Create → Read → Destroy using safe,
+// non-routable IPs and RFC 2606 reserved domains.
+//
+// The fix: Read now actually writes the device values into Terraform state
+// (dns_servers, dns_domains, id). Before the fix, these assignments were
+// commented out, breaking drift detection, state refresh, and import.
+//
+// Safety: Uses 10.255.255.x IPs (non-routable) and .invalid domains
+// (RFC 2606) per shared-device safety rules.
+func TestAccDNSReadRefreshesStateFromDevice(t *testing.T) {
+	expectedID := computeResourceID([]string{"10.255.255.60"}, []string{"acc-test-1.invalid"})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with one server and one domain.
+			// Verify Terraform state AND device both reflect the config.
+			// The fact that Read populates state from the device (not stale
+			// plan data) is what makes this test pass — before the fix,
+			// dns_servers and dns_domains in state were stale.
+			{
+				Config: testAccDNSCreateConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.60"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.0", "acc-test-1.invalid"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "id", expectedID),
+					// Direct API verification — bypasses Read
+					testAccCheckDNSServerPresentOnDevice("10.255.255.60"),
+					testAccCheckDNSDomainPresentOnDevice("acc-test-1.invalid"),
+				),
+			},
+			// Step 2: Destroy is automatic — CheckDestroy verifies cleanup
+		},
+	})
+}
+
+// TestAccDNSUpdateRefreshesState verifies that after an Update, Read
+// refreshes state from the device. Uses a single-server config that
+// changes between steps to avoid the additive PATCH issue.
+func TestAccDNSUpdateRefreshesState(t *testing.T) {
+	expectedID1 := computeResourceID([]string{"10.255.255.61"}, []string{"update-1.invalid"})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testAccDNSUpdateStep1Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.61"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.0", "update-1.invalid"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "id", expectedID1),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.61"),
+					testAccCheckDNSDomainPresentOnDevice("update-1.invalid"),
+				),
+			},
+			// Step 2: Update server and domain. The Update method now
+			// deletes stale entries before patching, so the plan should
+			// be clean after refresh.
+			{
+				Config: testAccDNSUpdateStep2Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.62"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.0", "update-2.invalid"),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.62"),
+					testAccCheckDNSDomainPresentOnDevice("update-2.invalid"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDNSReadStateMatchesDevice verifies that after a plan/apply cycle,
+// a subsequent Read produces state that matches the device. This is the
+// core behavior the fix enables: Read refreshing state from the API rather
+// than preserving stale prior state.
+func TestAccDNSReadStateMatchesDevice(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSReadVerifyConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.70"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.0", "read-verify.invalid"),
+					resource.TestCheckResourceAttrSet("f5os_dns.acc_test", "id"),
+					// Direct device checks — confirms Read wrote device
+					// values, not stale plan data
+					testAccCheckDNSServerPresentOnDevice("10.255.255.70"),
+					testAccCheckDNSDomainPresentOnDevice("read-verify.invalid"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test HCL configs
+// ---------------------------------------------------------------------------
+
+const testAccDNSCreateConfig = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.60"]
+  dns_domains = ["acc-test-1.invalid"]
+}
+`
+
+const testAccDNSUpdateStep1Config = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.61"]
+  dns_domains = ["update-1.invalid"]
+}
+`
+
+const testAccDNSUpdateStep2Config = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.62"]
+  dns_domains = ["update-2.invalid"]
+}
+`
+
+const testAccDNSReadVerifyConfig = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.70"]
+  dns_domains = ["read-verify.invalid"]
+}
+`
+
+// ---------------------------------------------------------------------------
+// Unit tests for search domain null entry fix
+// ---------------------------------------------------------------------------
+
+// TestUnitExtractStringListNullReturnsEmptySlice verifies that
+// extractStringList returns a non-nil empty slice when the input list is null.
+// Before the fix, it returned nil, which caused json.Marshal to produce
+// "search":null instead of "search":[] in the PATCH payload.
+func TestUnitExtractStringListNullReturnsEmptySlice(t *testing.T) {
+	ctx := context.Background()
+	nullList := types.ListNull(types.StringType)
+
+	result, diags := extractStringList(ctx, nullList)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if result == nil {
+		t.Fatal("extractStringList returned nil for null list; expected non-nil empty slice")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %v", result)
+	}
+}
+
+// TestUnitExtractStringListUnknownReturnsEmptySlice verifies that
+// extractStringList returns a non-nil empty slice for unknown lists.
+func TestUnitExtractStringListUnknownReturnsEmptySlice(t *testing.T) {
+	ctx := context.Background()
+	unknownList := types.ListUnknown(types.StringType)
+
+	result, diags := extractStringList(ctx, unknownList)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if result == nil {
+		t.Fatal("extractStringList returned nil for unknown list; expected non-nil empty slice")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %v", result)
+	}
+}
+
+// TestUnitExtractStringListWithValuesReturnsSlice verifies the normal case.
+func TestUnitExtractStringListWithValuesReturnsSlice(t *testing.T) {
+	ctx := context.Background()
+	list, diags := types.ListValueFrom(ctx, types.StringType, []string{"a", "b"})
+	if diags.HasError() {
+		t.Fatalf("failed to create list: %v", diags)
+	}
+
+	result, diags2 := extractStringList(ctx, list)
+	if diags2.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags2)
+	}
+	if len(result) != 2 || result[0] != "a" || result[1] != "b" {
+		t.Errorf("expected [a b], got %v", result)
+	}
+}
+
+// TestUnitDNSCreateOmitDomainsNoPatchNull verifies that when dns_domains
+// is omitted from the HCL config, the PATCH payload contains "search":[]
+// (empty array) rather than "search":null. The mock inspects the request
+// body and fails the test if it finds a null search field.
+func TestUnitDNSCreateOmitDomainsNoPatchNull(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/dns", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("failed to read PATCH body: %v", err)
+				http.Error(w, "read error", http.StatusInternalServerError)
+				return
+			}
+
+			// The raw JSON must not contain "search":null
+			if strings.Contains(string(body), `"search":null`) {
+				t.Error("PATCH payload contains \"search\":null — expected \"search\":[]")
+			}
+
+			// Verify it contains an empty array instead
+			var payload DNSConfigPayload
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("failed to unmarshal PATCH body: %v", err)
+				http.Error(w, "unmarshal error", http.StatusInternalServerError)
+				return
+			}
+			if payload.DNS.Config.Search == nil {
+				t.Error("PATCH payload Search is nil after unmarshal — expected non-nil empty slice")
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:dns": {
+					"servers": {"server": [{"address": "8.8.8.8"}]},
+					"config": {"search": []}
+				}
+			}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// dns_domains is omitted — should produce [] not null
+				Config: testUnitDNSOmitDomainsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testUnitDNSOmitDomainsConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+}
+`
+
+// TestUnitDNSReadNilDomainListProducesEmptyList verifies that when the
+// device returns empty/nil for the search list, Read produces an empty
+// Terraform list (dns_domains.# = 0) rather than a null value which
+// would cause a perpetual plan diff.
+func TestUnitDNSReadNilDomainListProducesEmptyList(t *testing.T) {
+	// Step 1 creates with servers + domains. Then we mutate the mock
+	// to return empty domains on the next GET, simulating the device
+	// having no search domains. Step 2 verifies Read sets domains to
+	// an empty list (not null).
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"internal.domain"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitDNSOneServer,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+				),
+			},
+			{
+				// Simulate device returning empty domains
+				PreConfig: func() {
+					st.domains = nil // nil, not []string{}
+				},
+				Config: testUnitDNSOmitDomainsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					// Key assertion: domains must be an empty list, not null
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitComputeResourceIDNilSlices verifies that computeResourceID
+// handles nil slices without panicking and produces a consistent hash.
+func TestUnitComputeResourceIDNilSlices(t *testing.T) {
+	id1 := computeResourceID(nil, nil)
+	id2 := computeResourceID([]string{}, []string{})
+
+	if id1 == "" {
+		t.Error("computeResourceID(nil, nil) returned empty string")
+	}
+	if id1 != id2 {
+		t.Errorf("nil and empty slices should produce the same ID; got %q vs %q", id1, id2)
+	}
+}
+
+// TestUnitRemovedEntriesNilInputs verifies removedEntries handles nil inputs.
+func TestUnitRemovedEntriesNilInputs(t *testing.T) {
+	// nil old, nil new — nothing removed
+	if got := removedEntries(nil, nil); len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+
+	// non-nil old, nil new — all removed
+	got := removedEntries([]string{"a", "b"}, nil)
+	if len(got) != 2 {
+		t.Errorf("expected 2 removed, got %v", got)
+	}
+
+	// nil old, non-nil new — nothing removed
+	if got := removedEntries(nil, []string{"a"}); len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for search domain null entry fix
+// ---------------------------------------------------------------------------
+
+// testAccCheckDNSDomainAbsentOnDevice queries the device directly and
+// confirms the specified domain is NOT present in the DNS config. This is
+// used instead of checking for zero domains because PatchDNSConfig is
+// additive and Delete is a no-op, so other domains from prior tests may
+// be present.
+func testAccCheckDNSDomainAbsentOnDevice(domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newDNSClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		config, err := client.ReadDNSConfig()
+		if err != nil {
+			return fmt.Errorf("ReadDNSConfig failed: %w", err)
+		}
+		for _, d := range config.DNS.Config.Search {
+			if d == domain {
+				return fmt.Errorf("domain %q should have been removed but is still present on device (all domains: %v)",
+					domain, config.DNS.Config.Search)
+			}
+		}
+		return nil
+	}
+}
+
+// TestAccDNSCreateWithoutDomains verifies that creating an f5os_dns resource
+// with dns_domains omitted from the config:
+//  1. Applies without error (no "provider returned invalid result" panic).
+//  2. Sets dns_domains to an empty list in state (not null).
+//
+// Before the fix, Create returned null for dns_domains (a Computed attribute),
+// which caused the Terraform Plugin Framework to reject the apply with
+// "provider returned invalid result object after apply".
+//
+// Note: The implicit refresh-after-apply may show a non-empty plan because
+// the device has residual DNS entries from prior tests (PATCH is additive,
+// Delete is a no-op). This is a known pre-existing issue unrelated to the
+// null-domain fix. We use ExpectNonEmptyPlan to acknowledge this.
+//
+// Safety: Uses 10.255.255.x (non-routable) and .invalid domain (RFC 2606).
+func TestAccDNSCreateWithoutDomains(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccDNSNoDomains,
+				ExpectNonEmptyPlan: true, // residual device state from additive PATCH
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.80"),
+					// Key assertion: dns_domains is an empty list, not null.
+					// Before the fix, this step would fail with "provider
+					// returned invalid result object after apply".
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "0"),
+					resource.TestCheckResourceAttrSet("f5os_dns.acc_test", "id"),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.80"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDNSUpdateRemovesAllDomains verifies that updating an f5os_dns
+// resource to remove all search domains (transitioning from dns_domains
+// present to dns_domains omitted) results in:
+//  1. dns_domains.# = 0 in state after the update.
+//  2. The managed domain removed from the device.
+//
+// Before the fix, Update could return null for dns_domains, causing the
+// same "invalid result" error as Create.
+//
+// Note: ExpectNonEmptyPlan is set because the device may have residual
+// entries from prior tests (PATCH is additive, Delete is a no-op).
+//
+// Safety: Uses 10.255.255.x (non-routable) and .invalid domains (RFC 2606).
+func TestAccDNSUpdateRemovesAllDomains(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with a server and a domain.
+			{
+				Config:             testAccDNSWithOneDomain,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.81"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.0", "remove-me.invalid"),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.81"),
+					testAccCheckDNSDomainPresentOnDevice("remove-me.invalid"),
+				),
+			},
+			// Step 2: Update to remove all domains — must succeed and set
+			// dns_domains.# = 0 in state, with the managed domain gone
+			// from device.
+			{
+				Config: testAccDNSRemoveDomains,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.81"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "0"),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.81"),
+					testAccCheckDNSDomainAbsentOnDevice("remove-me.invalid"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDNSUpdateAddsDomains verifies the reverse path: creating without
+// dns_domains and then updating to add one. This exercises the Update code
+// path that was also fixed to avoid returning null for the Computed attribute.
+//
+// Note: ExpectNonEmptyPlan is set because the device may have residual
+// entries from prior tests (PATCH is additive, Delete is a no-op).
+//
+// Safety: Uses 10.255.255.x (non-routable) and .invalid domains (RFC 2606).
+func TestAccDNSUpdateAddsDomains(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDNSDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create without domains — verify state shows empty
+			// list and server is present on device.
+			{
+				Config:             testAccDNSNoDomains2,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.82"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "0"),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.82"),
+				),
+			},
+			// Step 2: Add a domain — Update must succeed and set
+			// dns_domains.# = 1 in state.
+			{
+				Config: testAccDNSWithAddedDomain,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_servers.0", "10.255.255.82"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.acc_test", "dns_domains.0", "added.invalid"),
+					testAccCheckDNSServerPresentOnDevice("10.255.255.82"),
+					testAccCheckDNSDomainPresentOnDevice("added.invalid"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test HCL configs for null-domain fix
+// ---------------------------------------------------------------------------
+
+const testAccDNSNoDomains = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.80"]
+}
+`
+
+const testAccDNSWithOneDomain = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.81"]
+  dns_domains = ["remove-me.invalid"]
+}
+`
+
+const testAccDNSRemoveDomains = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.81"]
+}
+`
+
+const testAccDNSNoDomains2 = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.82"]
+}
+`
+
+const testAccDNSWithAddedDomain = `
+resource "f5os_dns" "acc_test" {
+  dns_servers = ["10.255.255.82"]
+  dns_domains = ["added.invalid"]
+}
+`
+
+// ---------------------------------------------------------------------------
+// Unit tests for ReadDNSConfig empty response handling
+// ---------------------------------------------------------------------------
+
+// TestUnitDNSCreateWhenDeviceHasNoConfig verifies that Create succeeds when
+// the device has no pre-existing DNS configuration (API returns empty body
+// on the initial GET). Before the fix, ReadDNSConfig would fail with
+// "unexpected end of JSON input" on the empty response.
+func TestUnitDNSCreateWhenDeviceHasNoConfig(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	getCallCount := 0
+	mux.HandleFunc("/restconf/data/openconfig-system:system/dns", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			getCallCount++
+			if getCallCount == 1 {
+				// First GET (Create's pre-existing check): empty body
+				// simulates no DNS config on a fresh device.
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte{})
+			} else {
+				// Subsequent GETs (Read after Create): return the
+				// config that was patched so state reconciles.
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{
+					"openconfig-system:dns": {
+						"servers": {"server": [{"address": "8.8.8.8"}]},
+						"config": {"search": ["test.internal"]}
+					}
+				}`))
+			}
+		case "PATCH":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("Unexpected HTTP method: %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitDNSCreateNoExistingConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_domains.0", "test.internal"),
+				),
+			},
+		},
+	})
+}
+
+const testUnitDNSCreateNoExistingConfig = `
+resource "f5os_dns" "test" {
+  dns_servers = ["8.8.8.8"]
+  dns_domains = ["test.internal"]
+}
+`
+
+// TestUnitDNSReadHandlesEmptyArraysFromDevice verifies that Read handles
+// the device returning empty server and domain arrays gracefully. This
+// simulates the scenario where DNS entries were removed externally, but
+// the API still returns a valid JSON envelope with empty arrays.
+// Note: this does NOT test the empty-body path (len(resp)==0) — that is
+// covered by TestUnitDNSCreateWhenDeviceHasNoConfig.
+func TestUnitDNSReadHandlesEmptyArraysFromDevice(t *testing.T) {
+	st := setupDNSMock(t, []string{"8.8.8.8"}, []string{"test.internal"})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create resource with valid config
+			{
+				Config: testUnitDNSCreateNoExistingConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+				),
+			},
+			// Step 2: Simulate device returning empty arrays.
+			// The mock still returns valid JSON but with no entries.
+			{
+				PreConfig: func() {
+					st.servers = nil
+					st.domains = nil
+				},
+				Config: testUnitDNSCreateNoExistingConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.#", "1"),
+					resource.TestCheckResourceAttr("f5os_dns.test", "dns_servers.0", "8.8.8.8"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitDNSConfigPayloadUnmarshalEmpty verifies that unmarshaling an
+// empty JSON body into DNSConfigPayload produces usable zero-value fields
+// (nil slices) rather than a parse error. This validates the assumption
+// behind the ReadDNSConfig fix — that an empty DNSConfigPayload{} is safe
+// to use when the API returns no data.
+func TestUnitDNSConfigPayloadUnmarshalEmpty(t *testing.T) {
+	// Case 1: empty input should fail json.Unmarshal (this is what the fix guards against)
+	var config1 DNSConfigPayload
+	err := json.Unmarshal([]byte{}, &config1)
+	if err == nil {
+		t.Error("Expected json.Unmarshal to fail on empty input, but it succeeded")
+	}
+
+	// Case 2: an empty struct literal should be safe to use (nil slices, no panic)
+	config2 := &DNSConfigPayload{}
+	if config2.DNS.Servers.Server != nil {
+		t.Errorf("Expected nil servers slice, got %v", config2.DNS.Servers.Server)
+	}
+	if config2.DNS.Config.Search != nil {
+		t.Errorf("Expected nil search slice, got %v", config2.DNS.Config.Search)
+	}
+	// Verify ranging over nil slices doesn't panic
+	for _, s := range config2.DNS.Servers.Server {
+		t.Errorf("Unexpected server: %s", s.Address)
+	}
+	for _, d := range config2.DNS.Config.Search {
+		t.Errorf("Unexpected domain: %s", d)
+	}
+}

--- a/internal/provider/f5os_auth_resource.go
+++ b/internal/provider/f5os_auth_resource.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -14,9 +15,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	f5os "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
+
+// privateKeyOriginalAuthOrder is the private state key used to store the
+// device's pre-existing auth_order so Delete can restore it.
+const privateKeyOriginalAuthOrder = "original_auth_order"
+
+// privateKeyOriginalRoleGIDs is the private state key used to store the
+// device's pre-existing role GIDs so Delete can restore them.
+const privateKeyOriginalRoleGIDs = "original_role_gids"
+
+// privateStateSetter is satisfied by resp.Private on CreateResponse,
+// ReadResponse, and UpdateResponse.
+type privateStateSetter interface {
+	SetKey(ctx context.Context, key string, value []byte) diag.Diagnostics
+}
+
+// privateStateGetter is satisfied by req.Private on UpdateRequest and
+// DeleteRequest.
+type privateStateGetter interface {
+	GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics)
+}
 
 // Ensure interface satisfaction
 var _ resource.Resource = &AuthResource{}
@@ -32,6 +54,28 @@ type authRemoteRoleModel struct {
 	Rolename  types.String `tfsdk:"rolename"`
 	RemoteGID types.Int64  `tfsdk:"remote_gid"`
 	LDAPGroup types.String `tfsdk:"ldap_group"`
+}
+
+// passwordPolicyModel represents the password policy settings in Terraform state.
+type passwordPolicyModel struct {
+	MinLength           types.Int64 `tfsdk:"min_length"`
+	RequiredNumeric     types.Int64 `tfsdk:"required_numeric"`
+	RequiredUppercase   types.Int64 `tfsdk:"required_uppercase"`
+	RequiredLowercase   types.Int64 `tfsdk:"required_lowercase"`
+	RequiredSpecial     types.Int64 `tfsdk:"required_special"`
+	RequiredDifferences types.Int64 `tfsdk:"required_differences"`
+	RejectUsername      types.Bool  `tfsdk:"reject_username"`
+	ApplyToRoot         types.Bool  `tfsdk:"apply_to_root"`
+	Retries             types.Int64 `tfsdk:"retries"`
+	MaxLoginFailures    types.Int64 `tfsdk:"max_login_failures"`
+	UnlockTime          types.Int64 `tfsdk:"unlock_time"`
+	RootLockout         types.Bool  `tfsdk:"root_lockout"`
+	RootUnlockTime      types.Int64 `tfsdk:"root_unlock_time"`
+	MaxAge              types.Int64 `tfsdk:"max_age"`
+	// v1.7+ only fields
+	MaxLetterRepeat   types.Int64 `tfsdk:"max_letter_repeat"`
+	MaxSequenceRepeat types.Int64 `tfsdk:"max_sequence_repeat"`
+	MaxClassRepeat    types.Int64 `tfsdk:"max_class_repeat"`
 }
 
 type AuthResourceModel struct {
@@ -53,7 +97,8 @@ func (r *AuthResource) Configure(_ context.Context, req resource.ConfigureReques
 
 func (r *AuthResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage AAA authentication on F5OS. Includes authentication method order and role GID mappings.",
+		MarkdownDescription: "Manage AAA authentication on F5OS. Includes authentication method order, role GID mappings, and password policy.\n\n" +
+			"~> **NOTE:** Running `terraform destroy` will restore the original authentication order and revert any role GID changes made by this resource.",
 		Attributes: map[string]schema.Attribute{
 			"auth_order": schema.ListAttribute{
 				MarkdownDescription: "Ordered list of authentication methods. Allowed values: local, radius, tacacs, ldap.",
@@ -62,20 +107,78 @@ func (r *AuthResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Validators:          []validator.List{listAuthOrderValidator{}},
 			},
 			"password_policy": schema.SingleNestedAttribute{
-				MarkdownDescription: "Password policy settings (note: device enforces final policy).",
+				MarkdownDescription: "Password policy settings. Only fields you specify are managed; unspecified fields are left at device defaults.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
-					"min_length":        schema.Int64Attribute{Optional: true},
-					"max_length":        schema.Int64Attribute{Optional: true},
-					"history":           schema.Int64Attribute{Optional: true},
-					"max_age_days":      schema.Int64Attribute{Optional: true},
-					"min_classes":       schema.Int64Attribute{Optional: true},
-					"require_upper":     schema.BoolAttribute{Optional: true},
-					"require_lower":     schema.BoolAttribute{Optional: true},
-					"require_digit":     schema.BoolAttribute{Optional: true},
-					"require_special":   schema.BoolAttribute{Optional: true},
-					"allow_username":    schema.BoolAttribute{Optional: true},
-					"allow_consecutive": schema.BoolAttribute{Optional: true},
+					"min_length": schema.Int64Attribute{
+						MarkdownDescription: "Minimum password length.",
+						Optional:            true,
+					},
+					"required_numeric": schema.Int64Attribute{
+						MarkdownDescription: "Required numeric digit count.",
+						Optional:            true,
+					},
+					"required_uppercase": schema.Int64Attribute{
+						MarkdownDescription: "Required uppercase character count.",
+						Optional:            true,
+					},
+					"required_lowercase": schema.Int64Attribute{
+						MarkdownDescription: "Required lowercase character count.",
+						Optional:            true,
+					},
+					"required_special": schema.Int64Attribute{
+						MarkdownDescription: "Required special character count.",
+						Optional:            true,
+					},
+					"required_differences": schema.Int64Attribute{
+						MarkdownDescription: "Characters that must differ from previous password.",
+						Optional:            true,
+					},
+					"reject_username": schema.BoolAttribute{
+						MarkdownDescription: "Reject passwords containing the username.",
+						Optional:            true,
+					},
+					"apply_to_root": schema.BoolAttribute{
+						MarkdownDescription: "Apply password restrictions to root accounts.",
+						Optional:            true,
+					},
+					"retries": schema.Int64Attribute{
+						MarkdownDescription: "Password entry retries before failure.",
+						Optional:            true,
+					},
+					"max_login_failures": schema.Int64Attribute{
+						MarkdownDescription: "Failed login attempts before lockout.",
+						Optional:            true,
+					},
+					"unlock_time": schema.Int64Attribute{
+						MarkdownDescription: "Account unlock time in seconds (0 = manual).",
+						Optional:            true,
+					},
+					"root_lockout": schema.BoolAttribute{
+						MarkdownDescription: "Enable lockout of root accounts.",
+						Optional:            true,
+					},
+					"root_unlock_time": schema.Int64Attribute{
+						MarkdownDescription: "Root account unlock time in seconds.",
+						Optional:            true,
+					},
+					"max_age": schema.Int64Attribute{
+						MarkdownDescription: "Password max age in days (0 = never expires).",
+						Optional:            true,
+					},
+					// v1.7+ only fields
+					"max_letter_repeat": schema.Int64Attribute{
+						MarkdownDescription: "Max repeating lowercase letters allowed. Only supported on F5OS >= v1.7.",
+						Optional:            true,
+					},
+					"max_sequence_repeat": schema.Int64Attribute{
+						MarkdownDescription: "Max repeating letters/digits allowed. Only supported on F5OS >= v1.7.",
+						Optional:            true,
+					},
+					"max_class_repeat": schema.Int64Attribute{
+						MarkdownDescription: "Max repeating chars of any class allowed. Only supported on F5OS >= v1.7.",
+						Optional:            true,
+					},
 				},
 			},
 			"remote_roles": schema.SetNestedAttribute{
@@ -88,6 +191,7 @@ func (r *AuthResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						},
 						"remote_gid": schema.Int64Attribute{
 							Optional: true,
+							Computed: true,
 							Validators: []validator.Int64{
 								int64validator.AtLeast(1),
 							},
@@ -118,6 +222,13 @@ func (r *AuthResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// Create authentication order if provided
 	if !plan.AuthOrder.IsNull() && !plan.AuthOrder.IsUnknown() {
+		// Save the original auth order from the device before overwriting,
+		// so Delete can restore it instead of removing it entirely.
+		resp.Diagnostics.Append(r.snapshotAuthOrder(ctx, resp.Private)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		var methods []string
 		if diags := plan.AuthOrder.ElementsAs(ctx, &methods, false); !diags.HasError() {
 			tflog.Debug(ctx, "Creating auth order", map[string]any{"methods": methods})
@@ -135,6 +246,19 @@ func (r *AuthResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !plan.RemoteRoles.IsNull() && !plan.RemoteRoles.IsUnknown() {
 		var roles []authRemoteRoleModel
 		if diags := plan.RemoteRoles.ElementsAs(ctx, &roles, false); !diags.HasError() {
+			// Collect role names and snapshot their current GIDs on the
+			// device before overwriting, so Delete can restore them.
+			var roleNames []string
+			for _, rr := range roles {
+				if !rr.Rolename.IsNull() && !rr.Rolename.IsUnknown() {
+					roleNames = append(roleNames, rr.Rolename.ValueString())
+				}
+			}
+			resp.Diagnostics.Append(r.snapshotRoleGIDs(ctx, resp.Private, roleNames)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			for _, rr := range roles {
 				if rr.Rolename.IsNull() || rr.Rolename.IsUnknown() {
 					continue
@@ -158,12 +282,43 @@ func (r *AuthResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 	}
 
-	// Handle password policy (placeholder for future implementation)
+	// Handle password policy if provided
 	if !plan.PasswordPolicy.IsNull() && !plan.PasswordPolicy.IsUnknown() {
-		tflog.Warn(ctx, "Password policy configuration is not yet implemented")
+		var ppModel passwordPolicyModel
+		resp.Diagnostics.Append(plan.PasswordPolicy.As(ctx, &ppModel, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Version guard for v1.7+ fields
+		resp.Diagnostics.Append(r.validateV17Fields(ctx, &ppModel)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Write the password policy to the device
+		resp.Diagnostics.Append(r.writePasswordPolicy(ctx, &ppModel)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	plan.ID = types.StringValue("f5os-auth")
+
+	// Read back actual device state so Terraform detects any discrepancies
+	// between what was planned and what the device accepted.
+	if !plan.AuthOrder.IsNull() {
+		if err := r.readAuthOrder(ctx, &plan); err != nil {
+			resp.Diagnostics.AddError("Failed to read back auth order after create", err.Error())
+			return
+		}
+	}
+	if !plan.RemoteRoles.IsNull() {
+		if err := r.readRoleConfig(ctx, &plan); err != nil {
+			resp.Diagnostics.AddError("Failed to read back role config after create", err.Error())
+			return
+		}
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -174,36 +329,59 @@ func (r *AuthResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	// For unit tests, completely skip device reads to avoid post-apply consistency issues
-	// Check if we're in a unit test by looking for test-specific configuration
-	if strings.Contains(r.client.Host, "127.0.0.1") || strings.Contains(r.client.Host, "localhost") {
-		tflog.Debug(ctx, "Skipping device read in unit test environment")
-		// Only set ID if it's not already set
-		if state.ID.IsNull() || state.ID.IsUnknown() || state.ID.ValueString() == "" {
-			state.ID = types.StringValue("f5os-auth")
+	tflog.Debug(ctx, "Reading auth configuration from device")
+
+	// Detect import: all user-configurable fields are null because
+	// ImportStatePassthroughID only sets the ID.
+	isImport := state.AuthOrder.IsNull() && state.RemoteRoles.IsNull() && state.PasswordPolicy.IsNull()
+
+	// During import, snapshot the device's current auth_order into private
+	// state so Delete can restore it. Create handles this for the normal
+	// lifecycle, but import bypasses Create entirely.
+	//
+	// Role GIDs are NOT snapshotted here because import alone doesn't
+	// modify any role GIDs. The first apply after import will call Update,
+	// which uses ensureRoleGIDsSnapshotted to capture any roles before
+	// modifying them.
+	if isImport {
+		existing, diags := req.Private.GetKey(ctx, privateKeyOriginalAuthOrder)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-		return
+		if existing == nil {
+			resp.Diagnostics.Append(r.snapshotAuthOrder(ctx, resp.Private)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+		}
 	}
 
-	// For real devices, only read during import (when ID is not set)
-	if state.ID.IsNull() || state.ID.IsUnknown() || state.ID.ValueString() == "" {
-		tflog.Debug(ctx, "Reading auth configuration from device (import scenario)")
-
+	// Read auth_order from device when managed or during import.
+	if !state.AuthOrder.IsNull() || isImport {
 		if err := r.readAuthOrder(ctx, &state); err != nil {
-			tflog.Warn(ctx, "failed to read authentication order during import", map[string]any{"error": err.Error()})
+			resp.Diagnostics.AddError("Failed to read auth order from device", err.Error())
+			return
 		}
-
-		if err := r.readRoleConfig(ctx, &state); err != nil {
-			tflog.Warn(ctx, "failed to read role configuration during import", map[string]any{"error": err.Error()})
-		}
-
-		state.ID = types.StringValue("f5os-auth")
-	} else {
-		tflog.Debug(ctx, "Preserving existing auth resource state (post-apply consistency)")
-		// State is already populated from the request - no changes needed
 	}
 
+	// Read remote_roles from device when managed or during import.
+	if !state.RemoteRoles.IsNull() || isImport {
+		if err := r.readRoleConfig(ctx, &state); err != nil {
+			resp.Diagnostics.AddError("Failed to read role config from device", err.Error())
+			return
+		}
+	}
+
+	// Read password_policy from device when managed or during import.
+	if !state.PasswordPolicy.IsNull() || isImport {
+		resp.Diagnostics.Append(r.readPasswordPolicy(ctx, &state, isImport)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	state.ID = types.StringValue("f5os-auth")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -236,6 +414,14 @@ func (r *AuthResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			return
 		}
 
+		// If the user added new roles that weren't in the original
+		// Create snapshot, capture their device-side GIDs now before
+		// we overwrite them, so Delete can restore them later.
+		resp.Diagnostics.Append(r.ensureRoleGIDsSnapshotted(ctx, req.Private, resp.Private, roles)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		for _, role := range roles {
 			rolename := role.Rolename.ValueString()
 			var gidPtr *int64
@@ -251,15 +437,123 @@ func (r *AuthResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 	}
 
+	// Update password policy if specified
+	if !plan.PasswordPolicy.IsNull() && !plan.PasswordPolicy.IsUnknown() {
+		var ppModel passwordPolicyModel
+		resp.Diagnostics.Append(plan.PasswordPolicy.As(ctx, &ppModel, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Version guard for v1.7+ fields
+		resp.Diagnostics.Append(r.validateV17Fields(ctx, &ppModel)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Write the password policy to the device
+		resp.Diagnostics.Append(r.writePasswordPolicy(ctx, &ppModel)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	plan.ID = types.StringValue("f5os-auth")
+
+	// Read back actual device state so Terraform detects any discrepancies
+	// between what was planned and what the device accepted.
+	if !plan.AuthOrder.IsNull() {
+		if err := r.readAuthOrder(ctx, &plan); err != nil {
+			resp.Diagnostics.AddError("Failed to read back auth order after update", err.Error())
+			return
+		}
+	}
+	if !plan.RemoteRoles.IsNull() {
+		if err := r.readRoleConfig(ctx, &plan); err != nil {
+			resp.Diagnostics.AddError("Failed to read back role config after update", err.Error())
+			return
+		}
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *AuthResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// Best-effort removal of auth order only; do not alter global roles.
-	if err := r.deleteAuthOrder(ctx); err != nil {
-		tflog.Warn(ctx, "failed deleting auth order", map[string]any{"error": err.Error()})
+	// Restore the original auth order that was saved during Create, rather
+	// than deleting the authentication-method array entirely. This avoids
+	// nuking auth config that existed before Terraform managed it.
+	origData, diags := req.Private.GetKey(ctx, privateKeyOriginalAuthOrder)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
+
+	if origData != nil {
+		var origMethods []string
+		if err := json.Unmarshal(origData, &origMethods); err != nil {
+			tflog.Warn(ctx, "failed to deserialize original auth order from private state, falling back to delete",
+				map[string]any{"error": err.Error()})
+			if err := r.deleteAuthOrder(ctx); err != nil {
+				tflog.Warn(ctx, "failed deleting auth order", map[string]any{"error": err.Error()})
+			}
+		} else {
+			if err := r.restoreAuthOrder(ctx, origMethods); err != nil {
+				tflog.Warn(ctx, "failed restoring original auth order, falling back to delete",
+					map[string]any{"error": err.Error(), "methods": origMethods})
+				if err := r.deleteAuthOrder(ctx); err != nil {
+					tflog.Warn(ctx, "failed deleting auth order", map[string]any{"error": err.Error()})
+				}
+			}
+		}
+	} else {
+		// No original auth order saved (e.g., resource created before this fix).
+		// Fall back to the old behavior of deleting the auth order.
+		tflog.Warn(ctx, "No original auth order in private state, falling back to delete")
+		if err := r.deleteAuthOrder(ctx); err != nil {
+			tflog.Warn(ctx, "failed deleting auth order", map[string]any{"error": err.Error()})
+		}
+	}
+
+	// Restore the original role GIDs that were saved during Create/Import,
+	// so destroy does not leave modified GIDs on the device.
+	origRoleData, diags := req.Private.GetKey(ctx, privateKeyOriginalRoleGIDs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if origRoleData != nil {
+		var origGIDs map[string]int
+		if err := json.Unmarshal(origRoleData, &origGIDs); err != nil {
+			tflog.Warn(ctx, "failed to deserialize original role GIDs from private state, skipping role restoration",
+				map[string]any{"error": err.Error()})
+		} else {
+			for rolename, gid := range origGIDs {
+				if gid == 0 {
+					// The role had no remote-gid before Terraform managed it;
+					// delete the leaf to restore the unset state.
+					tflog.Debug(ctx, "Clearing role remote-gid", map[string]any{"rolename": rolename})
+					if err := r.client.ClearRoleRemoteGID(rolename); err != nil {
+						tflog.Warn(ctx, "failed clearing role remote-gid",
+							map[string]any{"rolename": rolename, "error": err.Error()})
+					}
+				} else {
+					gid64 := int64(gid)
+					tflog.Debug(ctx, "Restoring role config", map[string]any{"rolename": rolename, "gid": gid64})
+					if err := r.client.SetRoleConfig(rolename, &gid64); err != nil {
+						tflog.Warn(ctx, "failed restoring original role GID",
+							map[string]any{"rolename": rolename, "gid": gid64, "error": err.Error()})
+					}
+				}
+			}
+		}
+	} else {
+		tflog.Warn(ctx, "No original role GIDs in private state, skipping role restoration")
+	}
+
+	// Password policy is left as-is on destroy (no-op). The device always has
+	// a password policy; reverting to weaker defaults would be a security risk.
+
 	resp.State.RemoveResource(ctx)
 }
 
@@ -302,6 +596,128 @@ func (r *AuthResource) listRoles(ctx context.Context) (map[string]int, error) {
 	return r.client.GetRoles()
 }
 
+// snapshotAuthOrder reads the current auth_order from the device and saves it
+// to private state so Delete can restore it later. Does nothing if the device
+// has no auth_order configured.
+func (r *AuthResource) snapshotAuthOrder(ctx context.Context, private privateStateSetter) diag.Diagnostics {
+	var diags diag.Diagnostics
+	methods, err := r.getAuthOrder(ctx)
+	if err != nil {
+		diags.AddError("Failed to read original auth order from device", err.Error())
+		return diags
+	}
+	if methods == nil {
+		return diags
+	}
+	data, err := json.Marshal(methods)
+	if err != nil {
+		diags.AddError("Failed to serialize original auth order", err.Error())
+		return diags
+	}
+	diags.Append(private.SetKey(ctx, privateKeyOriginalAuthOrder, data)...)
+	if !diags.HasError() {
+		tflog.Debug(ctx, "Saved original auth order to private state", map[string]any{"original": methods})
+	}
+	return diags
+}
+
+// snapshotRoleGIDs reads the current role GIDs from the device for the
+// specified roles and saves them to private state so Delete can restore
+// them later.
+func (r *AuthResource) snapshotRoleGIDs(ctx context.Context, private privateStateSetter, roleNames []string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if len(roleNames) == 0 {
+		return diags
+	}
+
+	allRoles, err := r.listRoles(ctx)
+	if err != nil {
+		diags.AddError("Failed to read original role GIDs from device", err.Error())
+		return diags
+	}
+
+	// Build a map of only the roles the user declared, with their
+	// current GIDs on the device. Roles that don't exist yet get
+	// GID 0 (the device default / unset state).
+	snapshot := make(map[string]int, len(roleNames))
+	for _, name := range roleNames {
+		snapshot[name] = allRoles[name] // 0 if not present
+	}
+
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		diags.AddError("Failed to serialize original role GIDs", err.Error())
+		return diags
+	}
+	diags.Append(private.SetKey(ctx, privateKeyOriginalRoleGIDs, data)...)
+	if !diags.HasError() {
+		tflog.Debug(ctx, "Saved original role GIDs to private state", map[string]any{"original": snapshot})
+	}
+	return diags
+}
+
+// ensureRoleGIDsSnapshotted reads the existing role GID snapshot from
+// private state and checks whether any of the planned roles are missing
+// from it. For any new roles (added to the config after initial Create),
+// it reads their current device-side GIDs and merges them into the
+// snapshot so Delete can restore them.
+func (r *AuthResource) ensureRoleGIDsSnapshotted(ctx context.Context, privateReader privateStateGetter, privateWriter privateStateSetter, roles []authRemoteRoleModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Read the existing snapshot.
+	existingData, d := privateReader.GetKey(ctx, privateKeyOriginalRoleGIDs)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	existing := make(map[string]int)
+	if existingData != nil {
+		if err := json.Unmarshal(existingData, &existing); err != nil {
+			diags.AddError("Failed to deserialize existing role GID snapshot", err.Error())
+			return diags
+		}
+	}
+
+	// Find role names in the plan that are not yet in the snapshot.
+	var newNames []string
+	for _, rr := range roles {
+		if rr.Rolename.IsNull() || rr.Rolename.IsUnknown() {
+			continue
+		}
+		name := rr.Rolename.ValueString()
+		if _, ok := existing[name]; !ok {
+			newNames = append(newNames, name)
+		}
+	}
+
+	if len(newNames) == 0 {
+		return diags
+	}
+
+	// Read the current device GIDs for the new roles.
+	allRoles, err := r.listRoles(ctx)
+	if err != nil {
+		diags.AddError("Failed to read role GIDs from device for snapshot update", err.Error())
+		return diags
+	}
+	for _, name := range newNames {
+		existing[name] = allRoles[name] // 0 if not present on device
+	}
+
+	// Write the merged snapshot back.
+	data, err := json.Marshal(existing)
+	if err != nil {
+		diags.AddError("Failed to serialize updated role GID snapshot", err.Error())
+		return diags
+	}
+	diags.Append(privateWriter.SetKey(ctx, privateKeyOriginalRoleGIDs, data)...)
+	if !diags.HasError() {
+		tflog.Debug(ctx, "Merged new role GIDs into snapshot", map[string]any{"new_roles": newNames, "snapshot": existing})
+	}
+	return diags
+}
+
 // createAuthOrder sets the authentication method order
 func (r *AuthResource) createAuthOrder(ctx context.Context, methods []string) error {
 	tflog.Debug(ctx, "Creating auth order", map[string]any{"methods": methods})
@@ -334,19 +750,44 @@ func (r *AuthResource) readRoleConfig(ctx context.Context, state *AuthResourceMo
 		return err
 	}
 
+	// Build the set of role names the user configured so we can filter the
+	// device response to only those roles.
+	configuredNames := make(map[string]bool)
+	if !state.RemoteRoles.IsNull() && !state.RemoteRoles.IsUnknown() {
+		var existing []authRemoteRoleModel
+		diags := state.RemoteRoles.ElementsAs(ctx, &existing, false)
+		if diags.HasError() {
+			return fmt.Errorf("failed to read configured roles from state: %s", diags.Errors()[0].Detail())
+		}
+		for _, er := range existing {
+			if !er.Rolename.IsNull() && !er.Rolename.IsUnknown() {
+				configuredNames[er.Rolename.ValueString()] = true
+			}
+		}
+	}
+
 	var roleModels []authRemoteRoleModel
 	for name, gid := range roles {
+		// Only include roles the user declared in their config. During import,
+		// configuredNames is empty (no prior state), so include all roles.
+		if len(configuredNames) > 0 && !configuredNames[name] {
+			continue
+		}
 		item := authRemoteRoleModel{Rolename: types.StringValue(name)}
-		if gid >= 0 {
+		if gid > 0 {
 			item.RemoteGID = types.Int64Value(int64(gid))
 		}
 		roleModels = append(roleModels, item)
 	}
-	sv, _ := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
+
+	sv, diags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
 		"rolename":   types.StringType,
 		"remote_gid": types.Int64Type,
 		"ldap_group": types.StringType,
 	}}, roleModels)
+	if diags.HasError() {
+		return fmt.Errorf("failed to convert role models to set: %s", diags.Errors()[0].Detail())
+	}
 	state.RemoteRoles = sv
 	return nil
 }
@@ -361,6 +802,12 @@ func (r *AuthResource) updateAuthOrder(ctx context.Context, methods []string) er
 func (r *AuthResource) updateRoleConfig(ctx context.Context, rolename string, gid *int64) error {
 	tflog.Debug(ctx, "Updating role config", map[string]any{"rolename": rolename, "gid": gid})
 	return r.client.SetRoleConfig(rolename, gid)
+}
+
+// restoreAuthOrder restores the authentication method order to a previous state
+func (r *AuthResource) restoreAuthOrder(ctx context.Context, methods []string) error {
+	tflog.Debug(ctx, "Restoring auth order", map[string]any{"methods": methods})
+	return r.client.SetAuthOrder(methods)
 }
 
 // deleteAuthOrder removes the authentication method order
@@ -409,4 +856,344 @@ func (v listAuthOrderValidator) ValidateList(ctx context.Context, req validator.
 		}
 		seen[m] = true
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Password Policy helpers
+// ---------------------------------------------------------------------------
+
+// passwordPolicyAttrTypes returns the attr.Type map for the password_policy
+// SingleNestedAttribute. Used when constructing types.ObjectValue.
+func passwordPolicyAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"min_length":           types.Int64Type,
+		"required_numeric":     types.Int64Type,
+		"required_uppercase":   types.Int64Type,
+		"required_lowercase":   types.Int64Type,
+		"required_special":     types.Int64Type,
+		"required_differences": types.Int64Type,
+		"reject_username":      types.BoolType,
+		"apply_to_root":        types.BoolType,
+		"retries":              types.Int64Type,
+		"max_login_failures":   types.Int64Type,
+		"unlock_time":          types.Int64Type,
+		"root_lockout":         types.BoolType,
+		"root_unlock_time":     types.Int64Type,
+		"max_age":              types.Int64Type,
+		"max_letter_repeat":    types.Int64Type,
+		"max_sequence_repeat":  types.Int64Type,
+		"max_class_repeat":     types.Int64Type,
+	}
+}
+
+// validateV17Fields checks whether the user configured v1.7+ fields on a
+// device that doesn't support them. Returns diagnostics with errors if so.
+func (r *AuthResource) validateV17Fields(ctx context.Context, pp *passwordPolicyModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if platformVersionAtLeast(r.client.PlatformVersion, "v1.7") {
+		return diags
+	}
+	if !pp.MaxLetterRepeat.IsNull() && !pp.MaxLetterRepeat.IsUnknown() {
+		diags.AddError("Unsupported attribute",
+			"max_letter_repeat is not supported on F5OS versions below v1.7")
+	}
+	if !pp.MaxSequenceRepeat.IsNull() && !pp.MaxSequenceRepeat.IsUnknown() {
+		diags.AddError("Unsupported attribute",
+			"max_sequence_repeat is not supported on F5OS versions below v1.7")
+	}
+	if !pp.MaxClassRepeat.IsNull() && !pp.MaxClassRepeat.IsUnknown() {
+		diags.AddError("Unsupported attribute",
+			"max_class_repeat is not supported on F5OS versions below v1.7")
+	}
+	return diags
+}
+
+// readPasswordPolicy reads password policy from the device and refreshes
+// the PasswordPolicy field in the model.
+//
+// When isImport is true, all fields are populated from the device (since
+// there is no prior state). Otherwise, only fields already present in state
+// are refreshed — this avoids adding fields the user didn't declare.
+func (r *AuthResource) readPasswordPolicy(ctx context.Context, state *AuthResourceModel, isImport bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+	policy, err := r.client.GetPasswordPolicy()
+	if err != nil {
+		diags.AddError("Failed to read password policy from device", err.Error())
+		return diags
+	}
+
+	if isImport {
+		// Import: populate all fields from device
+		model := passwordPolicyConfigToModel(policy, r.client.PlatformVersion)
+		obj, d := types.ObjectValueFrom(ctx, passwordPolicyAttrTypes(), model)
+		diags.Append(d...)
+		if !diags.HasError() {
+			state.PasswordPolicy = obj
+		}
+		return diags
+	}
+
+	// Normal read: only refresh fields already in state
+	var current passwordPolicyModel
+	diags.Append(state.PasswordPolicy.As(ctx, &current, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return diags
+	}
+
+	if !current.MinLength.IsNull() && policy.MinLength != nil {
+		current.MinLength = types.Int64Value(*policy.MinLength)
+	}
+	if !current.RequiredNumeric.IsNull() && policy.RequiredNumeric != nil {
+		current.RequiredNumeric = types.Int64Value(*policy.RequiredNumeric)
+	}
+	if !current.RequiredUppercase.IsNull() && policy.RequiredUppercase != nil {
+		current.RequiredUppercase = types.Int64Value(*policy.RequiredUppercase)
+	}
+	if !current.RequiredLowercase.IsNull() && policy.RequiredLowercase != nil {
+		current.RequiredLowercase = types.Int64Value(*policy.RequiredLowercase)
+	}
+	if !current.RequiredSpecial.IsNull() && policy.RequiredSpecial != nil {
+		current.RequiredSpecial = types.Int64Value(*policy.RequiredSpecial)
+	}
+	if !current.RequiredDifferences.IsNull() && policy.RequiredDifferences != nil {
+		current.RequiredDifferences = types.Int64Value(*policy.RequiredDifferences)
+	}
+	if !current.RejectUsername.IsNull() && policy.RejectUsername != nil {
+		current.RejectUsername = types.BoolValue(*policy.RejectUsername)
+	}
+	if !current.ApplyToRoot.IsNull() && policy.ApplyToRoot != nil {
+		current.ApplyToRoot = types.BoolValue(*policy.ApplyToRoot)
+	}
+	if !current.Retries.IsNull() && policy.Retries != nil {
+		current.Retries = types.Int64Value(*policy.Retries)
+	}
+	if !current.MaxLoginFailures.IsNull() && policy.MaxLoginFailures != nil {
+		current.MaxLoginFailures = types.Int64Value(*policy.MaxLoginFailures)
+	}
+	if !current.UnlockTime.IsNull() && policy.UnlockTime != nil {
+		current.UnlockTime = types.Int64Value(*policy.UnlockTime)
+	}
+	if !current.RootLockout.IsNull() && policy.RootLockout != nil {
+		current.RootLockout = types.BoolValue(*policy.RootLockout)
+	}
+	if !current.RootUnlockTime.IsNull() && policy.RootUnlockTime != nil {
+		current.RootUnlockTime = types.Int64Value(*policy.RootUnlockTime)
+	}
+	if !current.MaxAge.IsNull() && policy.MaxAge != nil {
+		current.MaxAge = types.Int64Value(*policy.MaxAge)
+	}
+	if !current.MaxLetterRepeat.IsNull() && policy.MaxLetterRepeat != nil {
+		current.MaxLetterRepeat = types.Int64Value(*policy.MaxLetterRepeat)
+	}
+	if !current.MaxSequenceRepeat.IsNull() && policy.MaxSequenceRepeat != nil {
+		current.MaxSequenceRepeat = types.Int64Value(*policy.MaxSequenceRepeat)
+	}
+	if !current.MaxClassRepeat.IsNull() && policy.MaxClassRepeat != nil {
+		current.MaxClassRepeat = types.Int64Value(*policy.MaxClassRepeat)
+	}
+
+	obj, d := types.ObjectValueFrom(ctx, passwordPolicyAttrTypes(), current)
+	diags.Append(d...)
+	if !diags.HasError() {
+		state.PasswordPolicy = obj
+	}
+	return diags
+}
+
+// writePasswordPolicy converts the Terraform model to an API config struct
+// and sends it to the device via PATCH.
+func (r *AuthResource) writePasswordPolicy(ctx context.Context, pp *passwordPolicyModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	config := passwordPolicyModelToConfig(pp, r.client.PlatformVersion)
+	tflog.Debug(ctx, "Writing password policy to device")
+	if err := r.client.SetPasswordPolicy(config); err != nil {
+		diags.AddError("Failed to set password policy", err.Error())
+	}
+	return diags
+}
+
+// passwordPolicyModelToConfig converts a Terraform passwordPolicyModel to
+// an f5osclient PasswordPolicyConfig struct. Only non-null fields are set.
+// The deviceVersion parameter controls which version-specific fields are included.
+func passwordPolicyModelToConfig(pp *passwordPolicyModel, deviceVersion string) *f5os.PasswordPolicyConfig {
+	config := &f5os.PasswordPolicyConfig{}
+
+	if !pp.MinLength.IsNull() && !pp.MinLength.IsUnknown() {
+		v := pp.MinLength.ValueInt64()
+		config.MinLength = &v
+	}
+	if !pp.RequiredNumeric.IsNull() && !pp.RequiredNumeric.IsUnknown() {
+		v := pp.RequiredNumeric.ValueInt64()
+		config.RequiredNumeric = &v
+	}
+	if !pp.RequiredUppercase.IsNull() && !pp.RequiredUppercase.IsUnknown() {
+		v := pp.RequiredUppercase.ValueInt64()
+		config.RequiredUppercase = &v
+	}
+	if !pp.RequiredLowercase.IsNull() && !pp.RequiredLowercase.IsUnknown() {
+		v := pp.RequiredLowercase.ValueInt64()
+		config.RequiredLowercase = &v
+	}
+	if !pp.RequiredSpecial.IsNull() && !pp.RequiredSpecial.IsUnknown() {
+		v := pp.RequiredSpecial.ValueInt64()
+		config.RequiredSpecial = &v
+	}
+	if !pp.RequiredDifferences.IsNull() && !pp.RequiredDifferences.IsUnknown() {
+		v := pp.RequiredDifferences.ValueInt64()
+		config.RequiredDifferences = &v
+	}
+	if !pp.RejectUsername.IsNull() && !pp.RejectUsername.IsUnknown() {
+		v := pp.RejectUsername.ValueBool()
+		config.RejectUsername = &v
+	}
+	if !pp.ApplyToRoot.IsNull() && !pp.ApplyToRoot.IsUnknown() {
+		v := pp.ApplyToRoot.ValueBool()
+		config.ApplyToRoot = &v
+	}
+	if !pp.Retries.IsNull() && !pp.Retries.IsUnknown() {
+		v := pp.Retries.ValueInt64()
+		config.Retries = &v
+	}
+	if !pp.MaxLoginFailures.IsNull() && !pp.MaxLoginFailures.IsUnknown() {
+		v := pp.MaxLoginFailures.ValueInt64()
+		config.MaxLoginFailures = &v
+	}
+	if !pp.UnlockTime.IsNull() && !pp.UnlockTime.IsUnknown() {
+		v := pp.UnlockTime.ValueInt64()
+		config.UnlockTime = &v
+	}
+	if !pp.RootLockout.IsNull() && !pp.RootLockout.IsUnknown() {
+		v := pp.RootLockout.ValueBool()
+		config.RootLockout = &v
+	}
+	if !pp.RootUnlockTime.IsNull() && !pp.RootUnlockTime.IsUnknown() {
+		v := pp.RootUnlockTime.ValueInt64()
+		config.RootUnlockTime = &v
+	}
+	if !pp.MaxAge.IsNull() && !pp.MaxAge.IsUnknown() {
+		v := pp.MaxAge.ValueInt64()
+		config.MaxAge = &v
+	}
+
+	// v1.7+ fields — only include if device supports them
+	if platformVersionAtLeast(deviceVersion, "v1.7") {
+		if !pp.MaxLetterRepeat.IsNull() && !pp.MaxLetterRepeat.IsUnknown() {
+			v := pp.MaxLetterRepeat.ValueInt64()
+			config.MaxLetterRepeat = &v
+		}
+		if !pp.MaxSequenceRepeat.IsNull() && !pp.MaxSequenceRepeat.IsUnknown() {
+			v := pp.MaxSequenceRepeat.ValueInt64()
+			config.MaxSequenceRepeat = &v
+		}
+		if !pp.MaxClassRepeat.IsNull() && !pp.MaxClassRepeat.IsUnknown() {
+			v := pp.MaxClassRepeat.ValueInt64()
+			config.MaxClassRepeat = &v
+		}
+	}
+
+	return config
+}
+
+// passwordPolicyConfigToModel converts an f5osclient PasswordPolicyConfig
+// to a Terraform passwordPolicyModel for populating state.
+// The deviceVersion parameter controls which version-specific fields are populated.
+func passwordPolicyConfigToModel(config *f5os.PasswordPolicyConfig, deviceVersion string) passwordPolicyModel {
+	model := passwordPolicyModel{}
+
+	if config.MinLength != nil {
+		model.MinLength = types.Int64Value(*config.MinLength)
+	} else {
+		model.MinLength = types.Int64Null()
+	}
+	if config.RequiredNumeric != nil {
+		model.RequiredNumeric = types.Int64Value(*config.RequiredNumeric)
+	} else {
+		model.RequiredNumeric = types.Int64Null()
+	}
+	if config.RequiredUppercase != nil {
+		model.RequiredUppercase = types.Int64Value(*config.RequiredUppercase)
+	} else {
+		model.RequiredUppercase = types.Int64Null()
+	}
+	if config.RequiredLowercase != nil {
+		model.RequiredLowercase = types.Int64Value(*config.RequiredLowercase)
+	} else {
+		model.RequiredLowercase = types.Int64Null()
+	}
+	if config.RequiredSpecial != nil {
+		model.RequiredSpecial = types.Int64Value(*config.RequiredSpecial)
+	} else {
+		model.RequiredSpecial = types.Int64Null()
+	}
+	if config.RequiredDifferences != nil {
+		model.RequiredDifferences = types.Int64Value(*config.RequiredDifferences)
+	} else {
+		model.RequiredDifferences = types.Int64Null()
+	}
+	if config.RejectUsername != nil {
+		model.RejectUsername = types.BoolValue(*config.RejectUsername)
+	} else {
+		model.RejectUsername = types.BoolNull()
+	}
+	if config.ApplyToRoot != nil {
+		model.ApplyToRoot = types.BoolValue(*config.ApplyToRoot)
+	} else {
+		model.ApplyToRoot = types.BoolNull()
+	}
+	if config.Retries != nil {
+		model.Retries = types.Int64Value(*config.Retries)
+	} else {
+		model.Retries = types.Int64Null()
+	}
+	if config.MaxLoginFailures != nil {
+		model.MaxLoginFailures = types.Int64Value(*config.MaxLoginFailures)
+	} else {
+		model.MaxLoginFailures = types.Int64Null()
+	}
+	if config.UnlockTime != nil {
+		model.UnlockTime = types.Int64Value(*config.UnlockTime)
+	} else {
+		model.UnlockTime = types.Int64Null()
+	}
+	if config.RootLockout != nil {
+		model.RootLockout = types.BoolValue(*config.RootLockout)
+	} else {
+		model.RootLockout = types.BoolNull()
+	}
+	if config.RootUnlockTime != nil {
+		model.RootUnlockTime = types.Int64Value(*config.RootUnlockTime)
+	} else {
+		model.RootUnlockTime = types.Int64Null()
+	}
+	if config.MaxAge != nil {
+		model.MaxAge = types.Int64Value(*config.MaxAge)
+	} else {
+		model.MaxAge = types.Int64Null()
+	}
+
+	// v1.7+ fields — only populate if device supports them
+	if platformVersionAtLeast(deviceVersion, "v1.7") {
+		if config.MaxLetterRepeat != nil {
+			model.MaxLetterRepeat = types.Int64Value(*config.MaxLetterRepeat)
+		} else {
+			model.MaxLetterRepeat = types.Int64Null()
+		}
+		if config.MaxSequenceRepeat != nil {
+			model.MaxSequenceRepeat = types.Int64Value(*config.MaxSequenceRepeat)
+		} else {
+			model.MaxSequenceRepeat = types.Int64Null()
+		}
+		if config.MaxClassRepeat != nil {
+			model.MaxClassRepeat = types.Int64Value(*config.MaxClassRepeat)
+		} else {
+			model.MaxClassRepeat = types.Int64Null()
+		}
+	} else {
+		// Pre-v1.7: these fields don't exist on the device
+		model.MaxLetterRepeat = types.Int64Null()
+		model.MaxSequenceRepeat = types.Int64Null()
+		model.MaxClassRepeat = types.Int64Null()
+	}
+
+	return model
 }

--- a/internal/provider/f5os_auth_resource_test.go
+++ b/internal/provider/f5os_auth_resource_test.go
@@ -2,15 +2,22 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	f5os "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
@@ -80,18 +87,27 @@ func TestAuthResourceUnit_Models(t *testing.T) {
 	model.AuthOrder = authOrderList
 	assert.False(t, model.AuthOrder.IsNull(), "AuthOrder should not be null")
 
-	// Test PasswordPolicy field
+	// Test PasswordPolicy field with new schema attributes
 	passwordPolicyAttrs := map[string]attr.Value{
-		"min_length": types.Int64Value(8),
-		"max_length": types.Int64Value(32),
+		"min_length":           types.Int64Value(8),
+		"required_numeric":     types.Int64Value(1),
+		"required_uppercase":   types.Int64Value(1),
+		"required_lowercase":   types.Int64Value(1),
+		"required_special":     types.Int64Value(1),
+		"required_differences": types.Int64Value(5),
+		"reject_username":      types.BoolValue(true),
+		"apply_to_root":        types.BoolValue(false),
+		"retries":              types.Int64Value(3),
+		"max_login_failures":   types.Int64Value(5),
+		"unlock_time":          types.Int64Value(300),
+		"root_lockout":         types.BoolValue(true),
+		"root_unlock_time":     types.Int64Value(600),
+		"max_age":              types.Int64Value(90),
+		"max_letter_repeat":    types.Int64Null(),
+		"max_sequence_repeat":  types.Int64Null(),
+		"max_class_repeat":     types.Int64Null(),
 	}
-	passwordPolicyType := types.ObjectType{
-		AttrTypes: map[string]attr.Type{
-			"min_length": types.Int64Type,
-			"max_length": types.Int64Type,
-		},
-	}
-	passwordPolicyObj, _ := types.ObjectValue(passwordPolicyType.AttrTypes, passwordPolicyAttrs)
+	passwordPolicyObj, _ := types.ObjectValue(passwordPolicyAttrTypes(), passwordPolicyAttrs)
 	model.PasswordPolicy = passwordPolicyObj
 	assert.False(t, model.PasswordPolicy.IsNull(), "PasswordPolicy should not be null")
 }
@@ -213,20 +229,19 @@ func setupMockServer() *httptest.Server {
 			case "DELETE":
 				w.WriteHeader(http.StatusNoContent)
 			}
-		case "/restconf/data/openconfig-system:roles":
+		case "/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles":
 			switch r.Method {
 			case "GET":
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = fmt.Fprint(w, `{
-					"openconfig-system:roles": {
+					"f5-system-aaa:roles": {
 						"role": [
-							{
-								"name": "test-role",
-								"config": {
-									"role-name": "test-role"
-								}
-							}
+							{"rolename": "admin", "config": {"rolename": "admin", "gid": 9000, "remote-gid": "-"}},
+							{"rolename": "operator", "config": {"rolename": "operator", "gid": 9001, "remote-gid": 9001}},
+							{"rolename": "resource-admin", "config": {"rolename": "resource-admin", "gid": 9003, "remote-gid": "-"}},
+							{"rolename": "superuser", "config": {"rolename": "superuser", "gid": 9004, "remote-gid": "-"}},
+							{"rolename": "user", "config": {"rolename": "user", "gid": 9002, "remote-gid": "-"}}
 						]
 					}
 				}`)
@@ -283,12 +298,16 @@ func TestAuthResourceMocked_ClientMethods(t *testing.T) {
 		assert.NoError(t, err, "SetRoleConfig should not return error")
 	})
 
-	// // Test GetRoles method
-	// t.Run("GetRoles", func(t *testing.T) {
-	// 	result, err := client.GetRoles()
-	// 	assert.NoError(t, err, "GetRoles should not return error")
-	// 	assert.NotNil(t, result, "GetRoles should return result")
-	// })
+	// Test GetRoles method
+	t.Run("GetRoles", func(t *testing.T) {
+		result, err := client.GetRoles()
+		assert.NoError(t, err, "GetRoles should not return error")
+		assert.NotNil(t, result, "GetRoles should return result")
+		// operator is the only role with a numeric remote-gid in the mock
+		assert.Equal(t, 9001, result["operator"], "operator remote-gid should be 9001")
+		// roles with remote-gid: "-" should have 0
+		assert.Equal(t, 0, result["admin"], "admin remote-gid should be 0 (not configured)")
+	})
 }
 
 func TestAuthResourceMocked_ErrorHandling(t *testing.T) {
@@ -308,6 +327,8 @@ func TestAuthResourceMocked_ErrorHandling(t *testing.T) {
 
 	client, err := f5os.NewSession(config)
 	assert.NoError(t, err, "Client initialization should not fail")
+	// Use a short poll/retry interval so the 3-retry loop doesn't take 30s.
+	client.PollInterval = time.Millisecond
 
 	// Test that errors are properly handled
 	_, err = client.GetAuthOrder()
@@ -338,6 +359,761 @@ func TestAuthResourceMocked_ComplexConfig(t *testing.T) {
 	result, err := client.GetAuthOrder()
 	assert.NoError(t, err, "GetAuthOrder after complex config should not fail")
 	assert.NotNil(t, result, "GetAuthOrder should return result after complex config")
+}
+
+// TestAuthResourceMocked_ReadRoleConfigFiltering verifies that readRoleConfig
+// only populates state with roles the user declared in their config, not every
+// role on the device. Without filtering, a device with 5 built-in roles
+// (admin, operator, resource-admin, superuser, user) would inject all 5 into
+// state even if the user only configured 1, causing drift on the next plan.
+func TestAuthResourceMocked_ReadRoleConfigFiltering(t *testing.T) {
+	server := setupMockServer()
+	defer server.Close()
+
+	cfg := &f5os.F5osConfig{
+		Host:             server.URL,
+		User:             "test",
+		Password:         "test",
+		DisableSSLVerify: true,
+	}
+	client, err := f5os.NewSession(cfg)
+	assert.NoError(t, err, "Client initialization should not fail")
+
+	res := &AuthResource{client: client}
+	ctx := context.Background()
+
+	// Simulate a state where the user configured only the "operator" role.
+	// Use a GID (1234) that differs from what the mock returns (9001) so we
+	// can confirm readRoleConfig actually read from the device and updated
+	// state, rather than being a no-op that left state untouched.
+	operatorRole := authRemoteRoleModel{
+		Rolename:  types.StringValue("operator"),
+		RemoteGID: types.Int64Value(1234),
+	}
+	configuredSet, diags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
+		"rolename":   types.StringType,
+		"remote_gid": types.Int64Type,
+		"ldap_group": types.StringType,
+	}}, []authRemoteRoleModel{operatorRole})
+	assert.False(t, diags.HasError(), "Building configured roles set should not error")
+
+	state := &AuthResourceModel{
+		RemoteRoles: configuredSet,
+	}
+
+	// readRoleConfig should filter the 5 device roles down to just "operator"
+	err = res.readRoleConfig(ctx, state)
+	assert.NoError(t, err, "readRoleConfig should not return error")
+
+	var resultRoles []authRemoteRoleModel
+	diags = state.RemoteRoles.ElementsAs(ctx, &resultRoles, false)
+	assert.False(t, diags.HasError(), "Extracting roles from state should not error")
+
+	var resultNames []string
+	for _, r := range resultRoles {
+		resultNames = append(resultNames, r.Rolename.ValueString())
+	}
+
+	assert.Equal(t, 1, len(resultRoles),
+		"readRoleConfig should return only user-configured roles, got %v", resultNames)
+
+	if len(resultRoles) == 1 {
+		assert.Equal(t, "operator", resultRoles[0].Rolename.ValueString(),
+			"Single returned role should be 'operator'")
+		assert.Equal(t, int64(9001), resultRoles[0].RemoteGID.ValueInt64(),
+			"GID should be 9001 (from the device), not 1234 (from the seed state)")
+	}
+}
+
+// TestAuthResourceMocked_ReadRoleConfigImport verifies that readRoleConfig
+// returns all device roles when state.RemoteRoles is null (the import scenario).
+// During import, there's no prior config to filter against, so all roles should
+// be included in state.
+func TestAuthResourceMocked_ReadRoleConfigImport(t *testing.T) {
+	server := setupMockServer()
+	defer server.Close()
+
+	cfg := &f5os.F5osConfig{
+		Host:             server.URL,
+		User:             "test",
+		Password:         "test",
+		DisableSSLVerify: true,
+	}
+	client, err := f5os.NewSession(cfg)
+	assert.NoError(t, err, "Client initialization should not fail")
+
+	res := &AuthResource{client: client}
+	ctx := context.Background()
+
+	// Simulate import: RemoteRoles is null (no prior state)
+	state := &AuthResourceModel{
+		RemoteRoles: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
+			"rolename":   types.StringType,
+			"remote_gid": types.Int64Type,
+			"ldap_group": types.StringType,
+		}}),
+	}
+
+	err = res.readRoleConfig(ctx, state)
+	assert.NoError(t, err, "readRoleConfig should not return error")
+
+	var resultRoles []authRemoteRoleModel
+	diags := state.RemoteRoles.ElementsAs(ctx, &resultRoles, false)
+	assert.False(t, diags.HasError(), "Extracting roles from state should not error")
+
+	// During import, all 5 device roles should be returned
+	assert.Equal(t, 5, len(resultRoles),
+		"readRoleConfig should return all device roles during import")
+}
+
+// TestAuthResourceMocked_SnapshotRestoreRoundtrip exercises the full
+// Create → Destroy lifecycle through the Terraform framework with a mock
+// HTTP server. It verifies that:
+//  1. Create snapshots the pre-existing auth_order into private state.
+//  2. Delete reads the snapshot and restores it via PUT (not DELETE).
+//
+// The mock server tracks its state so CheckDestroy can verify the final
+// device state matches the pre-existing baseline.
+func TestAuthResourceMocked_SnapshotRestoreRoundtrip(t *testing.T) {
+	preExisting := `["openconfig-aaa-types:LOCAL","f5-openconfig-aaa-ldap:LDAP_ALL"]`
+	currentAuthMethods := preExisting
+	deleteCalled := false
+
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"openconfig-system:config":{"authentication-method":%s}}`, currentAuthMethods)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config/authentication-method", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			var payload struct {
+				Methods []string `json:"openconfig-system:authentication-method"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			b, _ := json.Marshal(payload.Methods)
+			currentAuthMethods = string(b)
+			w.WriteHeader(http.StatusNoContent)
+		case "DELETE":
+			deleteCalled = true
+			currentAuthMethods = "[]"
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	defer teardown()
+
+	tfresource.Test(t, tfresource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if currentAuthMethods != preExisting {
+				return fmt.Errorf("expected auth_order restored to %s, got %s", preExisting, currentAuthMethods)
+			}
+			if deleteCalled {
+				return fmt.Errorf("DELETE was called; expected PUT to restore original")
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			{
+				Config: `resource "f5os_auth" "test" { auth_order = ["local", "radius"] }`,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					func(s *terraform.State) error {
+						expected := `["openconfig-aaa-types:LOCAL","openconfig-aaa-types:RADIUS_ALL"]`
+						if currentAuthMethods != expected {
+							return fmt.Errorf("after create, expected device to have %s, got %s", expected, currentAuthMethods)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAuthResourceMocked_DeleteFallbackWhenNoSnapshot exercises the fallback
+// path in Delete when private state has no saved auth_order. This happens
+// when the device had no authentication-method configured at Create time
+// (getAuthOrder returns nil, so snapshotAuthOrder stores nothing). In this
+// case Delete should fall back to calling ClearAuthOrder (DELETE).
+func TestAuthResourceMocked_DeleteFallbackWhenNoSnapshot(t *testing.T) {
+	deleteCalled := false
+
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	// GET /config returns NO authentication-method — simulates a device
+	// with no pre-existing auth_order.
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"openconfig-system:config":{}}`)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config/authentication-method", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			w.WriteHeader(http.StatusNoContent)
+		case "DELETE":
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	defer teardown()
+
+	tfresource.Test(t, tfresource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if !deleteCalled {
+				return fmt.Errorf("expected DELETE fallback when no snapshot exists, but DELETE was not called")
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			{
+				Config: `resource "f5os_auth" "test" { auth_order = ["local", "radius"] }`,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAuthResourceDeleteRestoresOriginal verifies that when Terraform
+// destroys the f5os_auth resource, the auth_order is restored to whatever
+// was configured on the device before Terraform managed it, rather than
+// being deleted entirely.
+//
+// Strategy:
+//  1. Capture the device's current auth_order (the true baseline).
+//  2. Set a known auth_order on the device via direct API: ["local", "ldap"]
+//  3. Apply a Terraform config with auth_order = ["local", "radius"]
+//     — Create should snapshot ["local", "ldap"] into private state
+//  4. Terraform destroy runs automatically at the end of the test
+//     — Delete should restore ["local", "ldap"] from private state
+//  5. CheckDestroy verifies the device has ["local", "ldap"]
+//  6. t.Cleanup restores the true baseline captured in step 1.
+//
+// Safety: always keeps "local" first; restores original baseline in Cleanup.
+func TestAccAuthResourceDeleteRestoresOriginal(t *testing.T) {
+	preExisting := []string{"local", "ldap"}
+
+	client, err := newAuthClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create f5os client: %v", err)
+	}
+
+	// Capture the true device baseline before we touch anything.
+	trueBaseline, err := client.GetAuthOrder()
+	if err != nil {
+		t.Fatalf("Failed to read true device baseline: %v", err)
+	}
+	t.Logf("True device baseline auth_order: %v", mapOpenConfigMethodsToFriendly(trueBaseline))
+
+	// Set a known pre-existing auth_order so Create has something to snapshot.
+	if err := client.SetAuthOrder(preExisting); err != nil {
+		t.Fatalf("Failed to set pre-existing auth order: %v", err)
+	}
+	t.Logf("Pre-set device auth_order to %v", preExisting)
+
+	// Cleanup: restore the true baseline regardless of test outcome.
+	t.Cleanup(func() {
+		cleanupClient, err := newAuthClientFromEnv()
+		if err != nil {
+			t.Logf("WARNING: cleanup failed to create client: %v", err)
+			return
+		}
+		if trueBaseline == nil {
+			if err := cleanupClient.ClearAuthOrder(); err != nil {
+				t.Logf("WARNING: cleanup failed to clear auth order: %v", err)
+			} else {
+				t.Log("Cleanup: cleared auth_order (baseline had none)")
+			}
+		} else {
+			if err := cleanupClient.SetAuthOrder(mapOpenConfigMethodsToFriendly(trueBaseline)); err != nil {
+				t.Logf("WARNING: cleanup failed to restore auth order to %v: %v",
+					mapOpenConfigMethodsToFriendly(trueBaseline), err)
+			} else {
+				t.Logf("Cleanup: restored auth_order to %v", mapOpenConfigMethodsToFriendly(trueBaseline))
+			}
+		}
+	})
+
+	tfresource.Test(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			// After destroy, the device should have the pre-existing auth
+			// order restored, NOT an empty/deleted auth-method array.
+			c, err := newAuthClientFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to create client for destroy check: %w", err)
+			}
+			rawMethods, err := c.GetAuthOrder()
+			if err != nil {
+				return fmt.Errorf("failed to read auth order after destroy: %w", err)
+			}
+			actual := mapOpenConfigMethodsToFriendly(rawMethods)
+			if len(actual) != len(preExisting) {
+				return fmt.Errorf("expected auth_order %v restored after destroy, got %v", preExisting, actual)
+			}
+			for i, want := range preExisting {
+				if actual[i] != want {
+					return fmt.Errorf("auth_order[%d] mismatch: expected %q, got %q (full: expected %v, got %v)",
+						i, want, actual[i], preExisting, actual)
+				}
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			// Step 1: Create — Terraform sets auth_order to ["local", "radius"],
+			// which should snapshot the pre-existing ["local", "ldap"] first.
+			{
+				Config: testAccAuthResourceConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					testAccCheckAuthOrderApplied([]string{"local", "radius"}),
+				),
+			},
+			// Step 2: Destroy is automatic — CheckDestroy verifies the
+			// pre-existing ["local", "ldap"] was restored.
+		},
+	})
+}
+
+// TestAuthResourceMocked_RoleGIDRestoreDeletesWhenBaselineUnset exercises
+// the Delete path where the snapshotted GID is 0 (the role had no
+// remote-gid before Terraform). Delete should call ClearRoleRemoteGID
+// (HTTP DELETE on the remote-gid leaf) rather than SetRoleConfig (PATCH).
+func TestAuthResourceMocked_RoleGIDRestoreDeletesWhenBaselineUnset(t *testing.T) {
+	// Pre-existing state: operator has NO remote-gid (returns 0 from GetRoles).
+	operatorGID := 0
+	deleteCalledForRemoteGID := false
+
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"openconfig-system:config":{"authentication-method":["openconfig-aaa-types:LOCAL","openconfig-aaa-types:RADIUS_ALL"]}}`)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config/authentication-method", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		// operator has remote-gid "-" (unset) which GetRoles parses as 0
+		_, _ = fmt.Fprintf(w, `{
+			"f5-system-aaa:roles": {
+				"role": [
+					{"rolename": "admin", "config": {"rolename": "admin", "gid": 9000, "remote-gid": "-"}},
+					{"rolename": "operator", "config": {"rolename": "operator", "gid": 9001, "remote-gid": %s}}
+				]
+			}
+		}`, func() string {
+			if operatorGID == 0 {
+				return `"-"`
+			}
+			return strconv.Itoa(operatorGID)
+		}())
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			var payload struct {
+				Config struct {
+					Rolename string `json:"f5-system-aaa:rolename"`
+					GID      *int64 `json:"f5-system-aaa:remote-gid"`
+				} `json:"f5-system-aaa:config"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if payload.Config.GID != nil {
+				operatorGID = int(*payload.Config.GID)
+			}
+		case "DELETE":
+			deleteCalledForRemoteGID = true
+			operatorGID = 0
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	defer teardown()
+
+	tfresource.Test(t, tfresource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if !deleteCalledForRemoteGID {
+				return fmt.Errorf("expected DELETE to clear remote-gid during destroy, but DELETE was not called")
+			}
+			if operatorGID != 0 {
+				return fmt.Errorf("expected operator GID to be 0 (unset) after destroy, got %d", operatorGID)
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			{
+				Config: `resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+  remote_roles = [
+    {
+      rolename   = "operator"
+      remote_gid = 9999
+    },
+  ]
+}`,
+				Check: func(s *terraform.State) error {
+					if operatorGID != 9999 {
+						return fmt.Errorf("after create, expected operator GID 9999, got %d", operatorGID)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// TestAuthResourceMocked_RoleGIDNoSnapshotSkipsRestore verifies that when
+// private state has no saved role GIDs (e.g., the resource was created
+// before this fix, or no remote_roles were configured), Delete does not
+// attempt any role restoration and completes without error.
+func TestAuthResourceMocked_RoleGIDNoSnapshotSkipsRestore(t *testing.T) {
+	roleConfigPatched := false
+
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"openconfig-system:config":{}}`)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config/authentication-method", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	// No roles endpoint registered for GET — the resource config doesn't
+	// include remote_roles, so snapshotRoleGIDs is never called.
+	// Track whether any role PATCH happens during Delete.
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			roleConfigPatched = true
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	defer teardown()
+
+	tfresource.Test(t, tfresource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if roleConfigPatched {
+				return fmt.Errorf("expected no role config PATCH during destroy when no snapshot exists, but PATCH was called")
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			{
+				// Only auth_order, no remote_roles — no role snapshot should be taken.
+				Config: `resource "f5os_auth" "test" { auth_order = ["local", "radius"] }`,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+				),
+			},
+		},
+	})
+}
+
+// TestAuthResourceMocked_RoleGIDUpdateAddsNewRole verifies that when
+// an Update adds a new role that wasn't in the original Create config,
+// the new role's pre-existing GID is captured into the snapshot so that
+// Delete restores it.
+//
+// Scenario:
+//  1. Create with only operator (remote-gid 9999) — snapshots operator's
+//     pre-existing GID (9001) but NOT user-manager's.
+//  2. Update adds user-manager (remote-gid 8888) — ensureRoleGIDsSnapshotted
+//     should capture user-manager's pre-existing GID (7777) into the snapshot.
+//  3. Delete should restore operator to 9001 AND user-manager to 7777.
+func TestAuthResourceMocked_RoleGIDUpdateAddsNewRole(t *testing.T) {
+	operatorGID := 9001
+	userManagerGID := 7777
+
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"openconfig-system:config":{"authentication-method":["openconfig-aaa-types:LOCAL","openconfig-aaa-types:RADIUS_ALL"]}}`)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config/authentication-method", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{
+			"f5-system-aaa:roles": {
+				"role": [
+					{"rolename": "admin", "config": {"rolename": "admin", "gid": 9000, "remote-gid": "-"}},
+					{"rolename": "operator", "config": {"rolename": "operator", "gid": 9001, "remote-gid": %d}},
+					{"rolename": "user-manager", "config": {"rolename": "user-manager", "gid": 9005, "remote-gid": %d}}
+				]
+			}
+		}`, operatorGID, userManagerGID)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			var payload struct {
+				Config struct {
+					Rolename string `json:"f5-system-aaa:rolename"`
+					GID      *int64 `json:"f5-system-aaa:remote-gid"`
+				} `json:"f5-system-aaa:config"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if payload.Config.GID != nil {
+				switch payload.Config.Rolename {
+				case "operator":
+					operatorGID = int(*payload.Config.GID)
+				case "user-manager":
+					userManagerGID = int(*payload.Config.GID)
+				}
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	defer teardown()
+
+	tfresource.Test(t, tfresource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if operatorGID != 9001 {
+				return fmt.Errorf("expected operator GID restored to 9001, got %d", operatorGID)
+			}
+			if userManagerGID != 7777 {
+				return fmt.Errorf("expected user-manager GID restored to 7777, got %d", userManagerGID)
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			// Step 1: Create with only operator.
+			{
+				Config: `resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+  remote_roles = [
+    { rolename = "operator", remote_gid = 9999 },
+  ]
+}`,
+				Check: func(s *terraform.State) error {
+					if operatorGID != 9999 {
+						return fmt.Errorf("after create, expected operator GID 9999, got %d", operatorGID)
+					}
+					return nil
+				},
+			},
+			// Step 2: Update — add user-manager.
+			{
+				Config: `resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+  remote_roles = [
+    { rolename = "operator", remote_gid = 9999 },
+    { rolename = "user-manager", remote_gid = 8888 },
+  ]
+}`,
+				Check: func(s *terraform.State) error {
+					if userManagerGID != 8888 {
+						return fmt.Errorf("after update, expected user-manager GID 8888, got %d", userManagerGID)
+					}
+					return nil
+				},
+			},
+			// Step 3: Destroy is automatic — CheckDestroy verifies both
+			// roles are restored to their pre-Terraform values.
+		},
+	})
+}
+
+// TestAccAuthResourceDeleteRestoresRoleGIDs verifies that when Terraform
+// destroys the f5os_auth resource, the operator role GID is restored to
+// whatever was configured on the device before Terraform managed it.
+//
+// Strategy:
+//  1. Capture the device's current operator GID (the true baseline).
+//  2. Set a known operator GID on the device via direct API: 9050
+//  3. Apply a Terraform config with remote_roles operator GID = 9060
+//     — Create should snapshot 9050 into private state
+//  4. Terraform destroy runs automatically at the end of the test
+//     — Delete should restore 9050 from private state
+//  5. CheckDestroy verifies the device has operator GID 9050
+//  6. t.Cleanup restores the true baseline captured in step 1.
+func TestAccAuthResourceDeleteRestoresRoleGIDs(t *testing.T) {
+	preExistingGID := int64(9050)
+
+	client, err := newAuthClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create f5os client: %v", err)
+	}
+
+	// Capture the true device baseline before we touch anything.
+	originalRoles, err := client.GetRoles()
+	if err != nil {
+		t.Fatalf("Failed to read true device baseline roles: %v", err)
+	}
+	trueBaselineGID, hasOperator := originalRoles["operator"]
+	if !hasOperator {
+		t.Skip("Skipping: device has no 'operator' role to test with")
+	}
+	t.Logf("True device baseline operator GID: %d", trueBaselineGID)
+
+	// Pre-flight: verify we can modify role config on this device.
+	if err := client.SetRoleConfig("operator", &preExistingGID); err != nil {
+		if strings.Contains(err.Error(), "access denied") || strings.Contains(err.Error(), "403") {
+			t.Skip("Skipping role test: admin user lacks permission to modify role config on this device")
+		}
+		t.Skipf("Skipping role test: unexpected error testing role config access: %v", err)
+	}
+	t.Logf("Pre-set device operator GID to %d", preExistingGID)
+
+	// Cleanup: restore the true baseline regardless of test outcome.
+	t.Cleanup(func() {
+		cleanupClient, err := newAuthClientFromEnv()
+		if err != nil {
+			t.Logf("WARNING: cleanup failed to create client: %v", err)
+			return
+		}
+		if trueBaselineGID == 0 {
+			// Baseline had no remote-gid; delete the leaf to restore
+			// the unset state rather than leaving a test value behind.
+			if err := cleanupClient.ClearRoleRemoteGID("operator"); err != nil {
+				t.Logf("WARNING: cleanup failed to clear operator remote-gid: %v", err)
+			} else {
+				t.Log("Cleanup: cleared operator remote-gid (baseline had none)")
+			}
+			return
+		}
+		gid := int64(trueBaselineGID)
+		if err := cleanupClient.SetRoleConfig("operator", &gid); err != nil {
+			t.Logf("WARNING: cleanup failed to restore operator GID to %d: %v", trueBaselineGID, err)
+		} else {
+			t.Logf("Cleanup: restored operator GID to %d", trueBaselineGID)
+		}
+	})
+
+	tfresource.Test(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			c, err := newAuthClientFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to create client for destroy check: %w", err)
+			}
+			roles, err := c.GetRoles()
+			if err != nil {
+				return fmt.Errorf("failed to read roles after destroy: %w", err)
+			}
+			actualGID, exists := roles["operator"]
+			if !exists {
+				return fmt.Errorf("operator role not found on device after destroy")
+			}
+			if int64(actualGID) != preExistingGID {
+				return fmt.Errorf("expected operator GID %d restored after destroy, got %d", preExistingGID, actualGID)
+			}
+			return nil
+		},
+		Steps: []tfresource.TestStep{
+			{
+				Config: `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+  remote_roles = [
+    {
+      rolename   = "operator"
+      remote_gid = 9060
+    },
+  ]
+}`,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					testAccCheckAuthOrderApplied([]string{"local", "radius"}),
+					testAccCheckRoleGIDApplied("operator", 9060),
+				),
+			},
+			// Destroy is automatic — CheckDestroy verifies the pre-existing
+			// operator GID (9050) was restored.
+		},
+	})
 }
 
 // Helper functions - removed unused helper functions
@@ -649,4 +1425,1113 @@ func TestAuthResourceIntegration_HTTPMethods(t *testing.T) {
 	// Test DELETE method
 	err = client.ClearAuthOrder()
 	assert.NoError(t, err, "DELETE method should not fail")
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance Tests (require live F5OS device with TF_ACC=1)
+// ---------------------------------------------------------------------------
+
+// newAuthClientFromEnv creates a fresh f5osclient from environment variables.
+// Used by custom check functions to verify device state independently of the
+// resource's Read method.
+func newAuthClientFromEnv() (*f5os.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888 // Default matches the provider (provider.go:104)
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5os.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5os.NewSession(cfg)
+}
+
+// mapOpenConfigMethodsToFriendly converts OpenConfig auth method identifiers
+// to user-friendly names (same mapping as in the resource's getAuthOrder).
+func mapOpenConfigMethodsToFriendly(methods []string) []string {
+	methodMap := map[string]string{
+		"openconfig-aaa-types:LOCAL":      "local",
+		"openconfig-aaa-types:RADIUS_ALL": "radius",
+		"openconfig-aaa-types:TACACS_ALL": "tacacs",
+		"f5-openconfig-aaa-ldap:LDAP_ALL": "ldap",
+	}
+	out := make([]string, 0, len(methods))
+	for _, m := range methods {
+		if friendly, ok := methodMap[m]; ok {
+			out = append(out, friendly)
+		} else {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// testAccCheckAuthOrderApplied queries the device directly to verify the
+// authentication order matches the expected methods (order-sensitive).
+func testAccCheckAuthOrderApplied(expectedMethods []string) tfresource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newAuthClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create f5os client: %w", err)
+		}
+		rawMethods, err := client.GetAuthOrder()
+		if err != nil {
+			return fmt.Errorf("failed to read auth order from device: %w", err)
+		}
+		actualMethods := mapOpenConfigMethodsToFriendly(rawMethods)
+
+		if len(actualMethods) != len(expectedMethods) {
+			return fmt.Errorf("auth order length mismatch: expected %v, got %v", expectedMethods, actualMethods)
+		}
+		for i, expected := range expectedMethods {
+			if actualMethods[i] != expected {
+				return fmt.Errorf("auth order mismatch at index %d: expected %q, got %q (full: expected %v, got %v)",
+					i, expected, actualMethods[i], expectedMethods, actualMethods)
+			}
+		}
+		return nil
+	}
+}
+
+// testAccCheckAuthDestroy verifies that the auth order was cleared after
+// terraform destroy. Note: Delete intentionally does NOT remove role GID
+// configurations, so we only check that auth_order was removed.
+func testAccCheckAuthDestroy(s *terraform.State) error {
+	client, err := newAuthClientFromEnv()
+	if err != nil {
+		// Cannot connect — treat as destroyed
+		return nil
+	}
+	rawMethods, err := client.GetAuthOrder()
+	if err != nil {
+		// If the GET fails (e.g., 404 because the path was deleted), that's fine
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			return nil
+		}
+		return fmt.Errorf("unexpected error checking auth order after destroy: %w", err)
+	}
+	// After ClearAuthOrder (DELETE), the response may return nil/empty or
+	// the device may fall back to a default. Accept nil/empty as "destroyed".
+	if len(rawMethods) == 0 {
+		return nil
+	}
+	// Some F5OS versions may return a default auth order after clearing.
+	// Only fail if the test-specific methods (radius, tacacs) are still present,
+	// since those would indicate our config was not cleaned up.
+	friendly := mapOpenConfigMethodsToFriendly(rawMethods)
+	for _, m := range friendly {
+		if m == "radius" || m == "tacacs" {
+			return fmt.Errorf("auth order still contains test method %q after destroy: %v", m, friendly)
+		}
+	}
+	return nil
+}
+
+// TestAccAuthResource is a real-device acceptance test for the f5os_auth resource.
+// It tests the full Terraform lifecycle: Create, Import, Update, Destroy.
+//
+// Safety:
+//   - auth_order always keeps "local" first
+//   - Each step is verified via direct API calls, not just Terraform state
+func TestAccAuthResource(t *testing.T) {
+	tfresource.Test(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAuthDestroy,
+		Steps: []tfresource.TestStep{
+			// Step 1: Create — set auth_order to local + radius
+			{
+				Config: testAccAuthResourceConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					// Terraform state checks
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					tfresource.TestCheckResourceAttrSet("f5os_auth.test", "id"),
+					// Direct API verification — proves the device accepted the config
+					testAccCheckAuthOrderApplied([]string{"local", "radius"}),
+				),
+			},
+			// Step 2: Import state
+			{
+				ResourceName:      "f5os_auth.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// remote_roles: import reads all device roles, not just
+				// user-declared ones, so imported state won't match config.
+				// password_policy: not implemented.
+				ImportStateVerifyIgnore: []string{"remote_roles", "password_policy"},
+			},
+			// Step 3: Update — change auth_order to local + tacacs
+			{
+				Config: testAccAuthResourceConfigUpdated,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					// Terraform state checks
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "tacacs"),
+					tfresource.TestCheckResourceAttrSet("f5os_auth.test", "id"),
+					// Direct API verification
+					testAccCheckAuthOrderApplied([]string{"local", "tacacs"}),
+				),
+			},
+			// Step 4: Destroy is automatic — CheckDestroy verifies cleanup
+		},
+	})
+}
+
+// TestAccAuthResourceDriftDetection proves that the Read method queries the
+// device after Create/Update so that Terraform can detect out-of-band changes.
+//
+// Strategy:
+//  1. Apply auth_order = ["local", "radius"] — establishes Terraform-managed state.
+//  2. Between steps, mutate the device directly via API to ["local", "tacacs"]
+//     (simulating an out-of-band change / drift).
+//  3. Re-apply the same ["local", "radius"] config.
+//     - If Read queries the device: Terraform sees the drift, detects a diff,
+//     and re-applies ["local", "radius"]. The device ends up correct.
+//     - If Read is broken (preserves plan state): Terraform thinks nothing
+//     changed, skips the apply, and the device stays at ["local", "tacacs"].
+//  4. Verify via direct API that the device has ["local", "radius"].
+//
+// Safety: always keeps "local" first; restores baseline on destroy.
+func TestAccAuthResourceDriftDetection(t *testing.T) {
+	tfresource.Test(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAuthDestroy,
+		Steps: []tfresource.TestStep{
+			// Step 1: Create — set auth_order to ["local", "radius"]
+			{
+				Config: testAccAuthResourceConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					testAccCheckAuthOrderApplied([]string{"local", "radius"}),
+				),
+			},
+			// Step 2: Inject drift, then re-apply the SAME config.
+			// PreConfig runs before Terraform plans this step.
+			{
+				PreConfig: func() {
+					// Mutate the device behind Terraform's back
+					client, err := newAuthClientFromEnv()
+					if err != nil {
+						t.Fatalf("drift injection: failed to create client: %v", err)
+					}
+					if err := client.SetAuthOrder([]string{"local", "tacacs"}); err != nil {
+						t.Fatalf("drift injection: failed to set auth order: %v", err)
+					}
+					t.Log("drift injection: device auth_order changed to [local, tacacs]")
+				},
+				// Re-apply the original config. If Read detects the drift,
+				// Terraform will see a diff and re-apply ["local", "radius"].
+				Config: testAccAuthResourceConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					// Terraform state should show the desired config
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					// Critical: the DEVICE must actually have ["local", "radius"].
+					// If Read is broken, the device will still have ["local", "tacacs"]
+					// and this check will fail.
+					testAccCheckAuthOrderApplied([]string{"local", "radius"}),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckRoleGIDApplied queries the device directly to verify a role's
+// GID matches the expected value.
+func testAccCheckRoleGIDApplied(rolename string, expectedGID int) tfresource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newAuthClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create f5os client: %w", err)
+		}
+		roles, err := client.GetRoles()
+		if err != nil {
+			return fmt.Errorf("failed to read roles from device: %w", err)
+		}
+		actualGID, exists := roles[rolename]
+		if !exists {
+			return fmt.Errorf("role %q not found on device; available roles: %v", rolename, roles)
+		}
+		if actualGID != expectedGID {
+			return fmt.Errorf("role %q GID mismatch: expected %d, got %d", rolename, expectedGID, actualGID)
+		}
+		return nil
+	}
+}
+
+// TestAccAuthResourceWithRoles tests the full lifecycle of auth_order together
+// with remote_roles: Create, Import, Update, Destroy.
+//
+// This validates that:
+//   - SetRoleConfig can write role GIDs via PATCH to the RESTCONF API
+//   - Import correctly reads role GIDs and filters to user-configured roles only
+//   - Role GID updates are applied to the device
+//
+// Safety:
+//   - auth_order always keeps "local" first
+//   - Only modifies the "operator" role GID (never admin/root/tenant-console)
+//   - Restores the original operator GID after the test via t.Cleanup
+//   - Pre-flight check skips gracefully if the device blocks role writes
+func TestAccAuthResourceWithRoles(t *testing.T) {
+	// Pre-flight: check if we can modify role config on this device
+	client, err := newAuthClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create f5os client: %v", err)
+	}
+
+	// Save the operator role's current GID so we can restore it after the test
+	originalRoles, err := client.GetRoles()
+	if err != nil {
+		t.Skipf("Cannot read roles from device: %v", err)
+	}
+	originalOperatorGID, hasOperator := originalRoles["operator"]
+	if !hasOperator {
+		t.Skip("Skipping: device has no 'operator' role to test with")
+	}
+	t.Cleanup(func() {
+		restoreClient, err := newAuthClientFromEnv()
+		if err != nil {
+			t.Logf("WARNING: failed to create client for operator GID restore: %v", err)
+			return
+		}
+		if originalOperatorGID == 0 {
+			if err := restoreClient.ClearRoleRemoteGID("operator"); err != nil {
+				t.Logf("WARNING: failed to clear operator remote-gid: %v", err)
+			} else {
+				t.Log("Cleanup: cleared operator remote-gid (baseline had none)")
+			}
+			return
+		}
+		gid := int64(originalOperatorGID)
+		if err := restoreClient.SetRoleConfig("operator", &gid); err != nil {
+			t.Logf("WARNING: failed to restore operator GID to %d: %v", originalOperatorGID, err)
+		} else {
+			t.Logf("Restored operator GID to %d", originalOperatorGID)
+		}
+	})
+
+	// Verify we can write a role GID before running the full test.
+	// Use 9099 (different from the test GIDs 9010/9011) so the pre-flight
+	// doesn't make Step 1's Create a no-op. Cleanup restores the original.
+	probeGID := int64(9099)
+	if err := client.SetRoleConfig("operator", &probeGID); err != nil {
+		if strings.Contains(err.Error(), "access denied") || strings.Contains(err.Error(), "403") {
+			t.Skip("Skipping role test: admin user lacks permission to modify role config on this device")
+		}
+		t.Skipf("Skipping role test: unexpected error testing role config access: %v", err)
+	}
+
+	tfresource.Test(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAuthDestroy,
+		Steps: []tfresource.TestStep{
+			// Step 1: Create — auth_order + operator role GID
+			{
+				Config: testAccAuthResourceWithRolesConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+					tfresource.TestCheckResourceAttrSet("f5os_auth.test", "id"),
+					testAccCheckAuthOrderApplied([]string{"local", "radius"}),
+					testAccCheckRoleGIDApplied("operator", 9010),
+				),
+			},
+			// Step 2: Import state
+			// remote_roles: import reads all device roles (by design), not
+			// just user-declared ones, so imported state won't match config.
+			// password_policy: not implemented.
+			{
+				ResourceName:      "f5os_auth.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"remote_roles",    // import reads all device roles, not just user-declared
+					"password_policy", // not implemented
+				},
+			},
+			// Step 3: Update — change auth_order and operator GID
+			{
+				Config: testAccAuthResourceWithRolesConfigUpdated,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.#", "2"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+					tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "tacacs"),
+					tfresource.TestCheckResourceAttrSet("f5os_auth.test", "id"),
+					testAccCheckAuthOrderApplied([]string{"local", "tacacs"}),
+					testAccCheckRoleGIDApplied("operator", 9011),
+				),
+			},
+			// Step 4: Destroy is automatic — CheckDestroy verifies cleanup
+		},
+	})
+}
+
+// testAccAuthResourceConfig — Create step: local+radius auth order only
+const testAccAuthResourceConfig = `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+}
+`
+
+// testAccAuthResourceConfigUpdated — Update step: local+tacacs auth order only
+const testAccAuthResourceConfigUpdated = `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "tacacs"]
+}
+`
+
+// testAccAuthResourceWithRolesConfig — Create step with roles.
+// GID 9010 is chosen to avoid conflicting with built-in role GIDs (9000-9004).
+const testAccAuthResourceWithRolesConfig = `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+
+  remote_roles = [
+    {
+      rolename   = "operator"
+      remote_gid = 9010
+    },
+  ]
+}
+`
+
+// testAccAuthResourceWithRolesConfigUpdated — Update step with roles.
+// GID 9011 is chosen to avoid conflicting with built-in role GIDs (9000-9004).
+const testAccAuthResourceWithRolesConfigUpdated = `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "tacacs"]
+
+  remote_roles = [
+    {
+      rolename   = "operator"
+      remote_gid = 9011
+    },
+  ]
+}
+`
+
+// ---------------------------------------------------------------------------
+// Password Policy Unit Tests
+// ---------------------------------------------------------------------------
+
+func TestAuthResourceUnit_PasswordPolicyModel(t *testing.T) {
+	// Test that the passwordPolicyModel struct can hold all 17 fields
+	model := passwordPolicyModel{
+		MinLength:           types.Int64Value(8),
+		RequiredNumeric:     types.Int64Value(1),
+		RequiredUppercase:   types.Int64Value(1),
+		RequiredLowercase:   types.Int64Value(1),
+		RequiredSpecial:     types.Int64Value(1),
+		RequiredDifferences: types.Int64Value(5),
+		RejectUsername:      types.BoolValue(true),
+		ApplyToRoot:         types.BoolValue(false),
+		Retries:             types.Int64Value(3),
+		MaxLoginFailures:    types.Int64Value(5),
+		UnlockTime:          types.Int64Value(300),
+		RootLockout:         types.BoolValue(true),
+		RootUnlockTime:      types.Int64Value(600),
+		MaxAge:              types.Int64Value(90),
+		// v1.7+ fields
+		MaxLetterRepeat:   types.Int64Value(3),
+		MaxSequenceRepeat: types.Int64Value(2),
+		MaxClassRepeat:    types.Int64Value(4),
+	}
+
+	assert.Equal(t, int64(8), model.MinLength.ValueInt64())
+	assert.Equal(t, int64(1), model.RequiredNumeric.ValueInt64())
+	assert.Equal(t, int64(1), model.RequiredUppercase.ValueInt64())
+	assert.Equal(t, int64(1), model.RequiredLowercase.ValueInt64())
+	assert.Equal(t, int64(1), model.RequiredSpecial.ValueInt64())
+	assert.Equal(t, int64(5), model.RequiredDifferences.ValueInt64())
+	assert.True(t, model.RejectUsername.ValueBool())
+	assert.False(t, model.ApplyToRoot.ValueBool())
+	assert.Equal(t, int64(3), model.Retries.ValueInt64())
+	assert.Equal(t, int64(5), model.MaxLoginFailures.ValueInt64())
+	assert.Equal(t, int64(300), model.UnlockTime.ValueInt64())
+	assert.True(t, model.RootLockout.ValueBool())
+	assert.Equal(t, int64(600), model.RootUnlockTime.ValueInt64())
+	assert.Equal(t, int64(90), model.MaxAge.ValueInt64())
+	assert.Equal(t, int64(3), model.MaxLetterRepeat.ValueInt64())
+	assert.Equal(t, int64(2), model.MaxSequenceRepeat.ValueInt64())
+	assert.Equal(t, int64(4), model.MaxClassRepeat.ValueInt64())
+}
+
+func TestPasswordPolicyModelToConfig(t *testing.T) {
+	model := &passwordPolicyModel{
+		MinLength:           types.Int64Value(10),
+		RequiredNumeric:     types.Int64Value(2),
+		RequiredUppercase:   types.Int64Value(1),
+		RequiredLowercase:   types.Int64Value(1),
+		RequiredSpecial:     types.Int64Value(1),
+		RequiredDifferences: types.Int64Value(6),
+		RejectUsername:      types.BoolValue(true),
+		ApplyToRoot:         types.BoolValue(false),
+		Retries:             types.Int64Value(5),
+		MaxLoginFailures:    types.Int64Value(10),
+		UnlockTime:          types.Int64Value(600),
+		RootLockout:         types.BoolValue(true),
+		RootUnlockTime:      types.Int64Value(900),
+		MaxAge:              types.Int64Value(180),
+		MaxLetterRepeat:     types.Int64Value(3),
+		MaxSequenceRepeat:   types.Int64Value(2),
+		MaxClassRepeat:      types.Int64Value(4),
+	}
+
+	// Test v1.7+ (includes v1.7+ fields)
+	configV17 := passwordPolicyModelToConfig(model, "1.7.0")
+	assert.NotNil(t, configV17)
+	assert.Equal(t, int64(10), *configV17.MinLength)
+	assert.Equal(t, int64(2), *configV17.RequiredNumeric)
+	assert.Equal(t, int64(1), *configV17.RequiredUppercase)
+	assert.Equal(t, int64(1), *configV17.RequiredLowercase)
+	assert.Equal(t, int64(1), *configV17.RequiredSpecial)
+	assert.Equal(t, int64(6), *configV17.RequiredDifferences)
+	assert.True(t, *configV17.RejectUsername)
+	assert.False(t, *configV17.ApplyToRoot)
+	assert.Equal(t, int64(5), *configV17.Retries)
+	assert.Equal(t, int64(10), *configV17.MaxLoginFailures)
+	assert.Equal(t, int64(600), *configV17.UnlockTime)
+	assert.True(t, *configV17.RootLockout)
+	assert.Equal(t, int64(900), *configV17.RootUnlockTime)
+	assert.Equal(t, int64(180), *configV17.MaxAge)
+	assert.Equal(t, int64(3), *configV17.MaxLetterRepeat)
+	assert.Equal(t, int64(2), *configV17.MaxSequenceRepeat)
+	assert.Equal(t, int64(4), *configV17.MaxClassRepeat)
+
+	// Test base case (omits v1.7+ fields)
+	config := passwordPolicyModelToConfig(model, "1.5.0")
+	assert.NotNil(t, config)
+	assert.Equal(t, int64(10), *config.MinLength)
+	assert.Nil(t, config.MaxLetterRepeat, "v1.7+ fields should be nil on base config")
+	assert.Nil(t, config.MaxSequenceRepeat, "v1.7+ fields should be nil on base config")
+	assert.Nil(t, config.MaxClassRepeat, "v1.7+ fields should be nil on base config")
+}
+
+func TestPasswordPolicyConfigToModel(t *testing.T) {
+	// Setup API config struct
+	minLen := int64(8)
+	reqNum := int64(1)
+	reqUpper := int64(1)
+	reqLower := int64(1)
+	reqSpecial := int64(1)
+	reqDiff := int64(5)
+	rejectUser := true
+	applyRoot := false
+	retries := int64(3)
+	maxFail := int64(5)
+	unlockTime := int64(300)
+	rootLockout := true
+	rootUnlock := int64(600)
+	maxAge := int64(90)
+	maxLetterRep := int64(3)
+	maxSeqRep := int64(2)
+	maxClassRep := int64(4)
+
+	config := &f5os.PasswordPolicyConfig{
+		MinLength:           &minLen,
+		RequiredNumeric:     &reqNum,
+		RequiredUppercase:   &reqUpper,
+		RequiredLowercase:   &reqLower,
+		RequiredSpecial:     &reqSpecial,
+		RequiredDifferences: &reqDiff,
+		RejectUsername:      &rejectUser,
+		ApplyToRoot:         &applyRoot,
+		Retries:             &retries,
+		MaxLoginFailures:    &maxFail,
+		UnlockTime:          &unlockTime,
+		RootLockout:         &rootLockout,
+		RootUnlockTime:      &rootUnlock,
+		MaxAge:              &maxAge,
+		MaxLetterRepeat:     &maxLetterRep,
+		MaxSequenceRepeat:   &maxSeqRep,
+		MaxClassRepeat:      &maxClassRep,
+	}
+
+	// Test v1.7+
+	modelV17 := passwordPolicyConfigToModel(config, "1.7.0")
+	assert.Equal(t, int64(8), modelV17.MinLength.ValueInt64())
+	assert.Equal(t, int64(1), modelV17.RequiredNumeric.ValueInt64())
+	assert.Equal(t, int64(1), modelV17.RequiredUppercase.ValueInt64())
+	assert.Equal(t, int64(1), modelV17.RequiredLowercase.ValueInt64())
+	assert.Equal(t, int64(1), modelV17.RequiredSpecial.ValueInt64())
+	assert.Equal(t, int64(5), modelV17.RequiredDifferences.ValueInt64())
+	assert.True(t, modelV17.RejectUsername.ValueBool())
+	assert.False(t, modelV17.ApplyToRoot.ValueBool())
+	assert.Equal(t, int64(3), modelV17.Retries.ValueInt64())
+	assert.Equal(t, int64(5), modelV17.MaxLoginFailures.ValueInt64())
+	assert.Equal(t, int64(300), modelV17.UnlockTime.ValueInt64())
+	assert.True(t, modelV17.RootLockout.ValueBool())
+	assert.Equal(t, int64(600), modelV17.RootUnlockTime.ValueInt64())
+	assert.Equal(t, int64(90), modelV17.MaxAge.ValueInt64())
+	assert.Equal(t, int64(3), modelV17.MaxLetterRepeat.ValueInt64())
+	assert.Equal(t, int64(2), modelV17.MaxSequenceRepeat.ValueInt64())
+	assert.Equal(t, int64(4), modelV17.MaxClassRepeat.ValueInt64())
+
+	// Test base case (v1.7+ fields should be null)
+	model := passwordPolicyConfigToModel(config, "1.5.0")
+	assert.Equal(t, int64(8), model.MinLength.ValueInt64())
+	assert.True(t, model.MaxLetterRepeat.IsNull(), "v1.7+ fields should be null on base config")
+	assert.True(t, model.MaxSequenceRepeat.IsNull(), "v1.7+ fields should be null on base config")
+	assert.True(t, model.MaxClassRepeat.IsNull(), "v1.7+ fields should be null on base config")
+}
+
+func TestPasswordPolicyAttrTypes(t *testing.T) {
+	attrTypes := passwordPolicyAttrTypes()
+	// Should have exactly 17 fields
+	assert.Equal(t, 17, len(attrTypes), "passwordPolicyAttrTypes should return 17 attribute types")
+
+	// Check all expected keys exist
+	expectedKeys := []string{
+		"min_length", "required_numeric", "required_uppercase", "required_lowercase",
+		"required_special", "required_differences", "reject_username", "apply_to_root",
+		"retries", "max_login_failures", "unlock_time", "root_lockout",
+		"root_unlock_time", "max_age", "max_letter_repeat", "max_sequence_repeat",
+		"max_class_repeat",
+	}
+	for _, key := range expectedKeys {
+		_, exists := attrTypes[key]
+		assert.True(t, exists, "attribute type %q should exist", key)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Password Policy Mocked HTTP Tests
+// ---------------------------------------------------------------------------
+
+// setupMockServerWithPasswordPolicy creates a mock server that handles
+// password policy endpoints in addition to auth_order and roles.
+func setupMockServerWithPasswordPolicy() *httptest.Server {
+	currentPolicy := map[string]interface{}{
+		"min-length":           6,
+		"required-numeric":     0,
+		"required-uppercase":   0,
+		"required-lowercase":   0,
+		"required-special":     0,
+		"required-differences": 8,
+		"reject-username":      false,
+		"apply-to-root":        true,
+		"retries":              3,
+		"max-login-failures":   10,
+		"unlock-time":          60,
+		"root-lockout":         true,
+		"root-unlock-time":     60,
+		"max-age":              0,
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/aaa/f5-openconfig-aaa-password-policy:password-policy/config"):
+			switch r.Method {
+			case "GET":
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				resp := map[string]interface{}{
+					"f5-openconfig-aaa-password-policy:config": currentPolicy,
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			case "PATCH":
+				var payload map[string]map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if config, ok := payload["f5-openconfig-aaa-password-policy:config"]; ok {
+					for k, v := range config {
+						currentPolicy[k] = v
+					}
+				}
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case strings.HasSuffix(r.URL.Path, "/aaa/authentication/config"):
+			switch r.Method {
+			case "GET":
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, `{
+					"openconfig-system:config": {
+						"authentication-method": ["openconfig-aaa-types:LOCAL", "openconfig-aaa-types:RADIUS_ALL"]
+					}
+				}`)
+			case "PUT", "PATCH":
+				w.WriteHeader(http.StatusNoContent)
+			case "DELETE":
+				w.WriteHeader(http.StatusNoContent)
+			}
+		case strings.HasSuffix(r.URL.Path, "/aaa/authentication/f5-system-aaa:roles"):
+			switch r.Method {
+			case "GET":
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, `{
+					"f5-system-aaa:roles": {
+						"role": [
+							{"rolename": "admin", "config": {"rolename": "admin", "gid": 9000, "remote-gid": "-"}},
+							{"rolename": "operator", "config": {"rolename": "operator", "gid": 9001, "remote-gid": 9001}}
+						]
+					}
+				}`)
+			case "PUT", "PATCH":
+				w.WriteHeader(http.StatusNoContent)
+			case "DELETE":
+				w.WriteHeader(http.StatusNoContent)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestAuthResourceMocked_PasswordPolicyClientMethods(t *testing.T) {
+	server := setupMockServerWithPasswordPolicy()
+	defer server.Close()
+
+	config := &f5os.F5osConfig{
+		Host:             server.URL,
+		User:             "test",
+		Password:         "test",
+		DisableSSLVerify: true,
+	}
+
+	client, err := f5os.NewSession(config)
+	assert.NoError(t, err, "Client initialization should not fail")
+	assert.NotNil(t, client, "Client should not be nil")
+
+	// Test GetPasswordPolicy method
+	t.Run("GetPasswordPolicy", func(t *testing.T) {
+		result, err := client.GetPasswordPolicy()
+		assert.NoError(t, err, "GetPasswordPolicy should not return error")
+		assert.NotNil(t, result, "GetPasswordPolicy should return result")
+		assert.NotNil(t, result.MinLength, "MinLength should be set")
+		assert.Equal(t, int64(6), *result.MinLength, "MinLength should be 6")
+	})
+
+	// Test SetPasswordPolicy method
+	t.Run("SetPasswordPolicy", func(t *testing.T) {
+		minLen := int64(10)
+		reqNum := int64(2)
+		newPolicy := &f5os.PasswordPolicyConfig{
+			MinLength:       &minLen,
+			RequiredNumeric: &reqNum,
+		}
+		err := client.SetPasswordPolicy(newPolicy)
+		assert.NoError(t, err, "SetPasswordPolicy should not return error")
+
+		// Verify the change took effect
+		result, err := client.GetPasswordPolicy()
+		assert.NoError(t, err, "GetPasswordPolicy after set should not fail")
+		assert.Equal(t, int64(10), *result.MinLength, "MinLength should be updated to 10")
+	})
+}
+
+// mockedPasswordPolicyTestParams holds the version-specific parts of a
+// mocked password policy lifecycle test.
+type mockedPasswordPolicyTestParams struct {
+	fixture string                     // path to the full /aaa fixture
+	version string                     // platform version ("" for default/pre-v1.7)
+	config  string                     // HCL config for the test step
+	checks  []tfresource.TestCheckFunc // Terraform state checks
+}
+
+// runMockedPasswordPolicyTest sets up a mock server with the given fixture
+// and version, then runs a Create/Read/Delete lifecycle test.
+func runMockedPasswordPolicyTest(t *testing.T, params mockedPasswordPolicyTestParams) {
+	t.Helper()
+
+	// Load initial policy from fixture
+	var fixture map[string]interface{}
+	if err := json.Unmarshal(loadFixtureBytes(params.fixture), &fixture); err != nil {
+		t.Fatalf("failed to load fixture %s: %v", params.fixture, err)
+	}
+	aaa := fixture["openconfig-system:aaa"].(map[string]interface{})
+	pp := aaa["f5-openconfig-aaa-password-policy:password-policy"].(map[string]interface{})
+	originalPolicy := pp["config"].(map[string]interface{})
+	currentPolicy := make(map[string]interface{})
+	for k, v := range originalPolicy {
+		currentPolicy[k] = v
+	}
+
+	testAccPreUnitCheck(t)
+
+	if params.version != "" {
+		setupMockPlatformVersion(mux, params.version)
+	}
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString(params.fixture))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"openconfig-system:config":{"authentication-method":["openconfig-aaa-types:LOCAL"]}}`)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/config/authentication-method", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-openconfig-aaa-password-policy:password-policy/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.Header().Set("Content-Type", "application/yang-data+json")
+			w.WriteHeader(http.StatusOK)
+			resp := map[string]interface{}{
+				"f5-openconfig-aaa-password-policy:config": currentPolicy,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "PATCH":
+			var payload map[string]map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if config, ok := payload["f5-openconfig-aaa-password-policy:config"]; ok {
+				for k, v := range config {
+					currentPolicy[k] = v
+				}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	defer teardown()
+
+	tfresource.Test(t, tfresource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: params.config,
+				Check:  tfresource.ComposeAggregateTestCheckFunc(params.checks...),
+			},
+		},
+	})
+}
+
+func TestAuthResourceMocked_PasswordPolicyCreateReadDelete(t *testing.T) {
+	runMockedPasswordPolicyTest(t, mockedPasswordPolicyTestParams{
+		fixture: "./fixtures/f5os_auth.json",
+		config: `
+resource "f5os_auth" "test" {
+  auth_order = ["local"]
+  password_policy = {
+    min_length         = 10
+    required_numeric   = 2
+    required_uppercase = 1
+    required_lowercase = 1
+    required_special   = 1
+    reject_username    = true
+    max_login_failures = 10
+    unlock_time        = 300
+  }
+}
+`,
+		checks: []tfresource.TestCheckFunc{
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.min_length", "10"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.required_numeric", "2"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.required_uppercase", "1"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.required_lowercase", "1"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.required_special", "1"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.reject_username", "true"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_login_failures", "10"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.unlock_time", "300"),
+		},
+	})
+}
+
+func TestAuthResourceMocked_PasswordPolicyV17CreateReadDelete(t *testing.T) {
+	runMockedPasswordPolicyTest(t, mockedPasswordPolicyTestParams{
+		fixture: "./fixtures/f5os_auth_v17.json",
+		version: "1.7.0",
+		config: `
+resource "f5os_auth" "test" {
+  auth_order = ["local"]
+  password_policy = {
+    min_length          = 10
+    max_letter_repeat   = 4
+    max_sequence_repeat = 3
+    max_class_repeat    = 2
+  }
+}
+`,
+		checks: []tfresource.TestCheckFunc{
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.min_length", "10"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_letter_repeat", "4"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_sequence_repeat", "3"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_class_repeat", "2"),
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Password Policy Acceptance Tests
+// ---------------------------------------------------------------------------
+
+// newPasswordPolicyClientFromEnv creates a fresh f5osclient from environment variables.
+// Used by password policy tests to verify device state independently.
+func newPasswordPolicyClientFromEnv() (*f5os.F5os, error) {
+	return newAuthClientFromEnv() // Reuse existing helper
+}
+
+// testAccCheckPasswordPolicyApplied queries the device directly to verify
+// password policy fields match expected values.
+func testAccCheckPasswordPolicyApplied(expected *f5os.PasswordPolicyConfig) tfresource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newPasswordPolicyClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create f5os client: %w", err)
+		}
+		policy, err := client.GetPasswordPolicy()
+		if err != nil {
+			return fmt.Errorf("failed to read password policy from device: %w", err)
+		}
+		// Check min-length (always present)
+		if expected.MinLength != nil {
+			if policy.MinLength == nil || *policy.MinLength != *expected.MinLength {
+				actual := "<nil>"
+				if policy.MinLength != nil {
+					actual = fmt.Sprintf("%d", *policy.MinLength)
+				}
+				return fmt.Errorf("min-length mismatch: expected %d, got %s", *expected.MinLength, actual)
+			}
+		}
+		// Check v1.7+ fields when expected
+		if expected.MaxLetterRepeat != nil {
+			if policy.MaxLetterRepeat == nil || *policy.MaxLetterRepeat != *expected.MaxLetterRepeat {
+				actual := "<nil>"
+				if policy.MaxLetterRepeat != nil {
+					actual = fmt.Sprintf("%d", *policy.MaxLetterRepeat)
+				}
+				return fmt.Errorf("max-letter-repeat mismatch: expected %d, got %s", *expected.MaxLetterRepeat, actual)
+			}
+		}
+		if expected.MaxSequenceRepeat != nil {
+			if policy.MaxSequenceRepeat == nil || *policy.MaxSequenceRepeat != *expected.MaxSequenceRepeat {
+				actual := "<nil>"
+				if policy.MaxSequenceRepeat != nil {
+					actual = fmt.Sprintf("%d", *policy.MaxSequenceRepeat)
+				}
+				return fmt.Errorf("max-sequence-repeat mismatch: expected %d, got %s", *expected.MaxSequenceRepeat, actual)
+			}
+		}
+		if expected.MaxClassRepeat != nil {
+			if policy.MaxClassRepeat == nil || *policy.MaxClassRepeat != *expected.MaxClassRepeat {
+				actual := "<nil>"
+				if policy.MaxClassRepeat != nil {
+					actual = fmt.Sprintf("%d", *policy.MaxClassRepeat)
+				}
+				return fmt.Errorf("max-class-repeat mismatch: expected %d, got %s", *expected.MaxClassRepeat, actual)
+			}
+		}
+		return nil
+	}
+}
+
+// TestAccAuthResourcePasswordPolicy tests the full lifecycle of password_policy:
+// Create, Import, Update, Destroy with restore.
+//
+// Automatically adapts to the device version:
+//   - Pre-v1.7: tests the 14 core fields only
+//   - v1.7+: also tests max_letter_repeat, max_sequence_repeat, max_class_repeat
+//
+// Safety:
+//   - Uses reasonable password policy values that won't lock users out
+//   - Restores original password policy on destroy
+//   - Uses t.Cleanup to restore baseline even if test fails
+func TestAccAuthResourcePasswordPolicy(t *testing.T) {
+	client, err := newPasswordPolicyClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create f5os client: %v", err)
+	}
+
+	deviceVersion := client.PlatformVersion
+	t.Logf("Device version: %s", deviceVersion)
+
+	// Capture the true device baseline before we touch anything
+	trueBaseline, err := client.GetPasswordPolicy()
+	if err != nil {
+		t.Fatalf("Failed to read true device baseline password policy: %v", err)
+	}
+	t.Logf("True device baseline min_length: %v", *trueBaseline.MinLength)
+
+	// Cleanup: restore the true baseline regardless of test outcome
+	t.Cleanup(func() {
+		cleanupClient, err := newPasswordPolicyClientFromEnv()
+		if err != nil {
+			t.Logf("WARNING: cleanup failed to create client: %v", err)
+			return
+		}
+		if err := cleanupClient.SetPasswordPolicy(trueBaseline); err != nil {
+			t.Logf("WARNING: cleanup failed to restore password policy: %v", err)
+		} else {
+			t.Logf("Cleanup: restored password policy to baseline (min_length=%v)", *trueBaseline.MinLength)
+		}
+	})
+
+	// Build version-appropriate configs and checks
+	createConfig, createChecks, createExpected := testAccPasswordPolicyCreateParams(deviceVersion)
+	updateConfig, updateChecks, updateExpected := testAccPasswordPolicyUpdateParams(deviceVersion)
+
+	tfresource.Test(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Step 1: Create with password_policy
+			{
+				Config: createConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					append(createChecks, testAccCheckPasswordPolicyApplied(createExpected))...,
+				),
+			},
+			// Step 2: Import state
+			{
+				ResourceName:      "f5os_auth.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"remote_roles",    // import reads all device roles, not just user-declared
+					"password_policy", // import reads all device fields, not just user-declared
+				},
+			},
+			// Step 3: Update password_policy
+			{
+				Config: updateConfig,
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					append(updateChecks, testAccCheckPasswordPolicyApplied(updateExpected))...,
+				),
+			},
+			// Step 4: Destroy is automatic — cleanup restores baseline
+		},
+	})
+}
+
+// testAccPasswordPolicyCreateParams returns the HCL config, Terraform state
+// checks, and expected API values for the Create step, adapted for the device version.
+func testAccPasswordPolicyCreateParams(deviceVersion string) (string, []tfresource.TestCheckFunc, *f5os.PasswordPolicyConfig) {
+	minLen := int64(10)
+	expected := &f5os.PasswordPolicyConfig{MinLength: &minLen}
+
+	checks := []tfresource.TestCheckFunc{
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.0", "local"),
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "auth_order.1", "radius"),
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.min_length", "10"),
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.required_numeric", "2"),
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.reject_username", "true"),
+	}
+
+	config := `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+
+  password_policy = {
+    min_length         = 10
+    required_numeric   = 2
+    required_uppercase = 1
+    required_lowercase = 1
+    required_special   = 1
+    reject_username    = true
+    max_login_failures = 10
+    unlock_time        = 300`
+
+	// v1.7+ added max-letter-repeat, max-sequence-repeat, max-class-repeat
+	if platformVersionAtLeast(deviceVersion, "v1.7") {
+		config += `
+    max_letter_repeat   = 4
+    max_sequence_repeat = 3
+    max_class_repeat    = 2`
+
+		checks = append(checks,
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_letter_repeat", "4"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_sequence_repeat", "3"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_class_repeat", "2"),
+		)
+		letterRep, seqRep, classRep := int64(4), int64(3), int64(2)
+		expected.MaxLetterRepeat = &letterRep
+		expected.MaxSequenceRepeat = &seqRep
+		expected.MaxClassRepeat = &classRep
+	}
+
+	config += `
+  }
+}
+`
+	return config, checks, expected
+}
+
+// testAccPasswordPolicyUpdateParams returns the HCL config, Terraform state
+// checks, and expected API values for the Update step, adapted for the device version.
+func testAccPasswordPolicyUpdateParams(deviceVersion string) (string, []tfresource.TestCheckFunc, *f5os.PasswordPolicyConfig) {
+	minLen := int64(12)
+	expected := &f5os.PasswordPolicyConfig{MinLength: &minLen}
+
+	checks := []tfresource.TestCheckFunc{
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.min_length", "12"),
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.required_numeric", "3"),
+		tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_login_failures", "5"),
+	}
+
+	config := `
+resource "f5os_auth" "test" {
+  auth_order = ["local", "radius"]
+
+  password_policy = {
+    min_length         = 12
+    required_numeric   = 3
+    required_uppercase = 2
+    required_lowercase = 2
+    required_special   = 1
+    reject_username    = true
+    max_login_failures = 5
+    unlock_time        = 600`
+
+	// v1.7+ added max-letter-repeat, max-sequence-repeat, max-class-repeat
+	if platformVersionAtLeast(deviceVersion, "v1.7") {
+		config += `
+    max_letter_repeat   = 5
+    max_sequence_repeat = 4
+    max_class_repeat    = 3`
+
+		checks = append(checks,
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_letter_repeat", "5"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_sequence_repeat", "4"),
+			tfresource.TestCheckResourceAttr("f5os_auth.test", "password_policy.max_class_repeat", "3"),
+		)
+		letterRep, seqRep, classRep := int64(5), int64(4), int64(3)
+		expected.MaxLetterRepeat = &letterRep
+		expected.MaxSequenceRepeat = &seqRep
+		expected.MaxClassRepeat = &classRep
+	}
+
+	config += `
+  }
+}
+`
+	return config, checks, expected
 }

--- a/internal/provider/f5os_ntp_server_resource.go
+++ b/internal/provider/f5os_ntp_server_resource.go
@@ -3,13 +3,18 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	f5os "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
+
+var _ resource.ResourceWithImportState = &NTPServerResource{}
 
 type NTPServerResource struct {
 	client *f5os.F5os
@@ -36,6 +41,9 @@ func (r *NTPServerResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"server": schema.StringAttribute{
 				MarkdownDescription: "IPv4/IPv6 address or FQDN of the NTP server.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"key_id": schema.Int64Attribute{
 				MarkdownDescription: "Key ID used for authentication with the NTP server. This should be configured with a key ID that has been already created on the system.",
@@ -52,10 +60,12 @@ func (r *NTPServerResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"ntp_service": schema.BoolAttribute{
 				MarkdownDescription: "Enable or disable the NTP service.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"ntp_authentication": schema.BoolAttribute{
 				MarkdownDescription: "Enable or disable NTP authentication.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -82,19 +92,48 @@ func (r *NTPServerResource) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("NTP Create Error", err.Error())
 		return
 	}
-	tflog.Info(ctx, "MDEBUG: Creating NTP Server", map[string]any{
+
+	// Patch global NTP config (service enable / authentication enable)
+	// when either attribute is explicitly set in the plan (not null and not
+	// unknown).  Unknown means the user omitted the attribute and Terraform
+	// is letting the provider compute it.
+	if !plan.NTPService.IsNull() && !plan.NTPService.IsUnknown() || !plan.NTPAuthentication.IsNull() && !plan.NTPAuthentication.IsUnknown() {
+		var svc, auth *bool
+		if !plan.NTPService.IsNull() && !plan.NTPService.IsUnknown() {
+			v := plan.NTPService.ValueBool()
+			svc = &v
+		}
+		if !plan.NTPAuthentication.IsNull() && !plan.NTPAuthentication.IsUnknown() {
+			v := plan.NTPAuthentication.ValueBool()
+			auth = &v
+		}
+		if err := r.client.PatchNTPGlobalConfig(svc, auth); err != nil {
+			resp.Diagnostics.AddError("NTP Global Config Error", err.Error())
+			return
+		}
+	}
+
+	// When ntp_service / ntp_authentication are omitted from the config they
+	// arrive as Unknown (Computed).  Resolve them from the device so the
+	// state always contains concrete values after apply.
+	if plan.NTPService.IsUnknown() || plan.NTPAuthentication.IsUnknown() {
+		svc, auth, err := r.client.GetNTPGlobalConfig()
+		if err != nil {
+			resp.Diagnostics.AddError("NTP Global Config Read Error", err.Error())
+			return
+		}
+		if plan.NTPService.IsUnknown() {
+			plan.NTPService = types.BoolValue(svc)
+		}
+		if plan.NTPAuthentication.IsUnknown() {
+			plan.NTPAuthentication = types.BoolValue(auth)
+		}
+	}
+
+	tflog.Info(ctx, "Creating NTP Server", map[string]any{
 		"server": plan.Server.ValueString(),
 	})
 
-	// print all the plan fields here
-	tflog.Debug(ctx, "MDEBUG: Create Plan", map[string]any{
-		"server":             plan.Server.ValueString(),
-		"key_id":             plan.KeyID.ValueInt64(),
-		"prefer":             plan.Prefer.ValueBool(),
-		"iburst":             plan.IBurst.ValueBool(),
-		"ntp_service":        plan.NTPService.ValueBool(),
-		"ntp_authentication": plan.NTPAuthentication.ValueBool(),
-	})
 	plan.ID = plan.Server
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -121,23 +160,33 @@ func (r *NTPServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	ntpService, ntpAuth, err := r.client.GetNTPGlobalConfig()
+	if err != nil {
+		resp.Diagnostics.AddError("NTP Global Config Read Error", err.Error())
+		return
+	}
+
 	state.ID = types.StringValue(state.Server.ValueString())
-	state.Server = types.StringValue(state.Server.ValueString())
-	// state.Server = types.StringValue(ntp.Address)
-	state.KeyID = types.Int64Value(int64(ntp.KeyID))
+	state.Server = types.StringValue(ntp.Address)
+	if ntp.KeyID != nil {
+		state.KeyID = types.Int64Value(*ntp.KeyID)
+	} else {
+		state.KeyID = types.Int64Null()
+	}
 	state.Prefer = types.BoolValue(ntp.Prefer)
 	state.IBurst = types.BoolValue(ntp.IBurst)
-	state.NTPService = types.BoolValue(ntp.NTPService)
-	state.NTPAuthentication = types.BoolValue(ntp.NTPAuthentication)
+	state.NTPService = types.BoolValue(ntpService)
+	state.NTPAuthentication = types.BoolValue(ntpAuth)
 
-	tflog.Debug(ctx, "MDEBUG: Current Read Result", map[string]any{
-		"server": ntp.Address,
-		"key_id": ntp.KeyID,
-		"id":     state.ID,
+	tflog.Debug(ctx, "NTP Read Result", map[string]any{
+		"server":             ntp.Address,
+		"key_id":             ntp.KeyID,
+		"prefer":             ntp.Prefer,
+		"iburst":             ntp.IBurst,
+		"ntp_service":        ntpService,
+		"ntp_authentication": ntpAuth,
+		"id":                 state.ID.ValueString(),
 	})
-	if state.ID.IsNull() || state.ID.IsUnknown() {
-		tflog.Error(ctx, "MDEBUG: ID is missing after read", nil)
-	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -149,7 +198,7 @@ func (r *NTPServerResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	payload, err := r.client.CreateNTPServerPayload(plan.Server.ValueString(), plan) // Reusing CreateNTPServerPayload
+	payload, err := r.client.UpdateNTPServerPayload(plan.Server.ValueString(), plan)
 	if err != nil {
 		resp.Diagnostics.AddError("Payload Creation Error", err.Error())
 		return
@@ -158,6 +207,39 @@ func (r *NTPServerResource) Update(ctx context.Context, req resource.UpdateReque
 	if err := r.client.UpdateNTPServer(plan.Server.ValueString(), payload); err != nil {
 		resp.Diagnostics.AddError("NTP Update Error", err.Error())
 		return
+	}
+
+	// Patch global NTP config (service enable / authentication enable)
+	// when either attribute is explicitly set in the plan.
+	if !plan.NTPService.IsNull() && !plan.NTPService.IsUnknown() || !plan.NTPAuthentication.IsNull() && !plan.NTPAuthentication.IsUnknown() {
+		var svc, auth *bool
+		if !plan.NTPService.IsNull() && !plan.NTPService.IsUnknown() {
+			v := plan.NTPService.ValueBool()
+			svc = &v
+		}
+		if !plan.NTPAuthentication.IsNull() && !plan.NTPAuthentication.IsUnknown() {
+			v := plan.NTPAuthentication.ValueBool()
+			auth = &v
+		}
+		if err := r.client.PatchNTPGlobalConfig(svc, auth); err != nil {
+			resp.Diagnostics.AddError("NTP Global Config Update Error", err.Error())
+			return
+		}
+	}
+
+	// Resolve unknown computed values from the device.
+	if plan.NTPService.IsUnknown() || plan.NTPAuthentication.IsUnknown() {
+		svc, auth, err := r.client.GetNTPGlobalConfig()
+		if err != nil {
+			resp.Diagnostics.AddError("NTP Global Config Read Error", err.Error())
+			return
+		}
+		if plan.NTPService.IsUnknown() {
+			plan.NTPService = types.BoolValue(svc)
+		}
+		if plan.NTPAuthentication.IsUnknown() {
+			plan.NTPAuthentication = types.BoolValue(auth)
+		}
 	}
 
 	plan.ID = plan.Server
@@ -177,6 +259,12 @@ func (r *NTPServerResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 }
 
+func (r *NTPServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("server"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	tflog.Info(ctx, "Importing NTP Server", map[string]any{"server": req.ID})
+}
+
 type NTPServerModel struct {
 	ID                types.String `tfsdk:"id"`
 	Server            types.String `tfsdk:"server"`
@@ -186,12 +274,3 @@ type NTPServerModel struct {
 	NTPService        types.Bool   `tfsdk:"ntp_service"`
 	NTPAuthentication types.Bool   `tfsdk:"ntp_authentication"`
 }
-
-// type NTPServerModel struct {
-// 	Server            string `tfsdk:"server"`
-// 	KeyID             int    `tfsdk:"key_id"`
-// 	Prefer            bool   `tfsdk:"prefer"`
-// 	IBurst            bool   `tfsdk:"iburst"`
-// 	NTPService        bool   `tfsdk:"ntp_service"`
-// 	NTPAuthentication bool   `tfsdk:"ntp_authentication"`
-// }

--- a/internal/provider/f5os_ntp_server_resource_test.go
+++ b/internal/provider/f5os_ntp_server_resource_test.go
@@ -1,20 +1,25 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
-	"os/exec"
+	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
 
-// can you please write the unit test and acceptance test cases for the ntp server resource?
-// fix all the issues in the unit test case.
-// Test configurations
-const testAccF5osNTPServerBasicConfig = `
+// ---------------------------------------------------------------------------
+// Unit-test HCL configs (use 10.20.30.40 — only hits mock server)
+// ---------------------------------------------------------------------------
+
+const testUnitNTPServerBasicConfig = `
 resource "f5os_ntp_server" "test" {
   server             = "10.20.30.40"
   key_id             = 123
@@ -25,10 +30,23 @@ resource "f5os_ntp_server" "test" {
 }
 `
 
-const testAccF5osNTPServerUpdatedConfig = `
+// ---------------------------------------------------------------------------
+// Acceptance-test HCL configs (use non-routable 10.255.255.x per safety rules)
+// ---------------------------------------------------------------------------
+
+const testAccNTPServerBasicConfig = `
 resource "f5os_ntp_server" "test" {
-  server             = "10.20.30.40"
-  key_id             = 456
+  server             = "10.255.255.1"
+  prefer             = true
+  iburst             = true
+  ntp_service        = true
+  ntp_authentication = true
+}
+`
+
+const testAccNTPServerUpdatedConfig = `
+resource "f5os_ntp_server" "test" {
+  server             = "10.255.255.1"
   prefer             = false
   iburst             = false
   ntp_service        = true
@@ -36,10 +54,125 @@ resource "f5os_ntp_server" "test" {
 }
 `
 
+// ---------------------------------------------------------------------------
+// Helper: create a fresh F5OS client from env vars (port defaults to 8888)
+// ---------------------------------------------------------------------------
+
+func newNtpClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888 // Must default to 8888 to match the provider
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
+
+// ---------------------------------------------------------------------------
+// Direct API verification: check NTP server exists on device with expected values
+// ---------------------------------------------------------------------------
+
+func testAccCheckNTPServerOnDevice(server string, expectKeyID int64, expectPrefer, expectIBurst bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newNtpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create F5OS client: %w", err)
+		}
+		ntp, err := client.GetNTPServer(server)
+		if err != nil {
+			return fmt.Errorf("failed to read NTP server %s from device: %w", server, err)
+		}
+		if ntp.Address != server {
+			return fmt.Errorf("expected NTP server address %q, got %q", server, ntp.Address)
+		}
+		var gotKeyID int64
+		if ntp.KeyID != nil {
+			gotKeyID = *ntp.KeyID
+		}
+		if gotKeyID != expectKeyID {
+			return fmt.Errorf("expected key_id %d, got %d", expectKeyID, gotKeyID)
+		}
+		if ntp.Prefer != expectPrefer {
+			return fmt.Errorf("expected prefer=%v, got %v", expectPrefer, ntp.Prefer)
+		}
+		if ntp.IBurst != expectIBurst {
+			return fmt.Errorf("expected iburst=%v, got %v", expectIBurst, ntp.IBurst)
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Direct API verification: check NTP global config on device
+// ---------------------------------------------------------------------------
+
+func testAccCheckNTPGlobalConfigOnDevice(expectService, expectAuth bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newNtpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create F5OS client: %w", err)
+		}
+		service, auth, err := client.GetNTPGlobalConfig()
+		if err != nil {
+			return fmt.Errorf("failed to read NTP global config from device: %w", err)
+		}
+		if service != expectService {
+			return fmt.Errorf("expected ntp_service=%v on device, got %v", expectService, service)
+		}
+		if auth != expectAuth {
+			return fmt.Errorf("expected ntp_authentication=%v on device, got %v", expectAuth, auth)
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CheckDestroy: verify test NTP server was removed from device
+// ---------------------------------------------------------------------------
+
+func testAccCheckNTPServerDestroy(s *terraform.State) error {
+	client, err := newNtpClientFromEnv()
+	if err != nil {
+		// Cannot connect — treat as destroyed
+		return nil
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "f5os_ntp_server" {
+			continue
+		}
+		server := rs.Primary.Attributes["server"]
+		if server == "" {
+			continue
+		}
+		ntp, err := client.GetNTPServer(server)
+		if err == nil && ntp != nil {
+			return fmt.Errorf("NTP server %s still exists on device after destroy", server)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Unit test (mock server)
+// ---------------------------------------------------------------------------
+
 func TestUnitF5osNTPServerResource(t *testing.T) {
 	testAccPreUnitCheck(t)
 
-	// Mock server interactions for NTP server endpoints
+	// Mock: POST to create NTP server
 	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "POST":
@@ -48,6 +181,7 @@ func TestUnitF5osNTPServerResource(t *testing.T) {
 		}
 	})
 
+	// Mock: GET/PATCH/DELETE for specific NTP server
 	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers/server=10.20.30.40", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "GET":
@@ -72,6 +206,7 @@ func TestUnitF5osNTPServerResource(t *testing.T) {
 		}
 	})
 
+	// Mock: GET/PATCH for global NTP config
 	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/config", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "PATCH":
@@ -89,29 +224,13 @@ func TestUnitF5osNTPServerResource(t *testing.T) {
 
 	defer teardown()
 
-}
-
-// TestAccF5osNTPServerResource runs acceptance tests for the NTP Server resource
-func TestAccF5osNTPServerResource(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Acceptance tests skipped unless TF_ACC set")
-	}
-
-	// Check if we can run the test
-	cmd := exec.Command("ping", "-c", "1", os.Getenv("F5OS_HOST"))
-	err := cmd.Run()
-	if err != nil {
-		t.Skipf("Unable to reach %s: %s", os.Getenv("F5OS_HOST"), err)
-	} else {
-		t.Logf("Connected to %s", os.Getenv("F5OS_HOST"))
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// Step 1: Create and verify
 			{
-				// Step 1: Test basic configuration
-				Config: testAccF5osNTPServerBasicConfig,
+				Config: testUnitNTPServerBasicConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("f5os_ntp_server.test", "server", "10.20.30.40"),
 					resource.TestCheckResourceAttr("f5os_ntp_server.test", "key_id", "123"),
@@ -121,58 +240,767 @@ func TestAccF5osNTPServerResource(t *testing.T) {
 					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_authentication", "true"),
 				),
 			},
+			// Step 2: Import state by server address — verifies ImportState
+			// passes the import ID through to the "server" attribute so that
+			// Read can query the device (mock) and populate all fields.
 			{
-				// Step 2: Test resource import
 				ResourceName:      "f5os_ntp_server.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test (real device)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Unit test: Create calls PatchNTPGlobalConfig when ntp_service/ntp_authentication are set
+// ---------------------------------------------------------------------------
+
+func TestUnitNTPGlobalConfigPatchedOnCreate(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var ntpConfigPatchCount int32
+
+	// Mock: POST to create NTP server
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	})
+
+	// Mock: GET/PATCH/DELETE for specific NTP server
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers/server=10.20.30.40", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:server": [{
+					"address": "10.20.30.40",
+					"config": {
+						"address": "10.20.30.40",
+						"f5-openconfig-system-ntp:key-id": 123,
+						"prefer": true,
+						"iburst": true
+					}
+				}]
+			}`))
+		case "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	// Mock: GET/PATCH for global NTP config — track PATCH calls
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			atomic.AddInt32(&ntpConfigPatchCount, 1)
+			defer func() { _ = r.Body.Close() }()
+			body, _ := io.ReadAll(r.Body)
+
+			var payload struct {
+				Config struct {
+					Enabled       *bool `json:"enabled,omitempty"`
+					EnableNTPAuth *bool `json:"enable-ntp-auth,omitempty"`
+				} `json:"config"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("failed to unmarshal PATCH /ntp/config body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if payload.Config.Enabled == nil {
+				t.Error("expected 'enabled' in PATCH body, got nil")
+			} else if *payload.Config.Enabled != true {
+				t.Errorf("expected enabled=true, got %v", *payload.Config.Enabled)
+			}
+			if payload.Config.EnableNTPAuth == nil {
+				t.Error("expected 'enable-ntp-auth' in PATCH body, got nil")
+			} else if *payload.Config.EnableNTPAuth != true {
+				t.Errorf("expected enable-ntp-auth=true, got %v", *payload.Config.EnableNTPAuth)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:config": {
+					"enabled": true,
+					"enable-ntp-auth": true
+				}
+			}`))
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitNTPServerBasicConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "server", "10.20.30.40"),
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "key_id", "123"),
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "prefer", "true"),
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "iburst", "true"),
 					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_service", "true"),
 					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_authentication", "true"),
-				),
-			},
-			{
-				// Step 3: Test resource update
-				Config: testAccF5osNTPServerUpdatedConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "server", "10.20.30.40"),
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "key_id", "456"),
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "prefer", "false"),
-					resource.TestCheckResourceAttr("f5os_ntp_server.test", "iburst", "false"),
-				),
-			},
-			{
-				// Step 4: Test resource destroy
-				Config: `
-                resource "f5os_ntp_server" "test" {
-                    # Empty config to trigger destroy
-                }
-            `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Use the custom TestCheckNoResourceExists to validate destroy
-					checkNoResourceExists("f5os_ntp_server.test"),
+					func(_ *terraform.State) error {
+						count := atomic.LoadInt32(&ntpConfigPatchCount)
+						if count == 0 {
+							return fmt.Errorf("PatchNTPGlobalConfig was never called during Create (PATCH /ntp/config count = 0)")
+						}
+						return nil
+					},
 				),
 			},
 		},
 	})
 }
 
-func checkNoResourceExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// Look for the resource in the state
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			// Resource not found in state, which is what we want
-			return nil
+// ---------------------------------------------------------------------------
+// Unit test: Update calls PatchNTPGlobalConfig when ntp_service/ntp_authentication change
+// ---------------------------------------------------------------------------
+
+const testUnitNTPServerUpdateNTPServiceConfig = `
+resource "f5os_ntp_server" "test" {
+  server             = "10.20.30.40"
+  key_id             = 123
+  prefer             = true
+  iburst             = true
+  ntp_service        = false
+  ntp_authentication = false
+}
+`
+
+func TestUnitNTPGlobalConfigPatchedOnUpdate(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var ntpConfigPatchCount int32
+	// Track the most recent PATCH payload to /ntp/config so we can verify
+	// that the Update step sends the updated values.
+	var lastPatchService, lastPatchAuth *bool
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
 		}
-		// If resource exists in state, it should be marked as tainted/destroyed
-		if rs.Primary.ID == "" {
-			return nil
+	})
+
+	// Track whether service was enabled or disabled in GET responses.
+	// Start enabled=true, auth=true; after PATCH with false, return false.
+	var globalEnabled int32 = 1
+	var globalAuth int32 = 1
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers/server=10.20.30.40", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:server": [{
+					"address": "10.20.30.40",
+					"config": {
+						"address": "10.20.30.40",
+						"f5-openconfig-system-ntp:key-id": 123,
+						"prefer": true,
+						"iburst": true
+					}
+				}]
+			}`))
+		case "PATCH":
+			w.WriteHeader(http.StatusNoContent)
+		case "DELETE":
+			w.WriteHeader(http.StatusNoContent)
 		}
-		return fmt.Errorf("resource %s still exists", name)
-	}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			atomic.AddInt32(&ntpConfigPatchCount, 1)
+			defer func() { _ = r.Body.Close() }()
+			body, _ := io.ReadAll(r.Body)
+
+			var payload struct {
+				Config struct {
+					Enabled       *bool `json:"enabled,omitempty"`
+					EnableNTPAuth *bool `json:"enable-ntp-auth,omitempty"`
+				} `json:"config"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("failed to unmarshal PATCH body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			lastPatchService = payload.Config.Enabled
+			lastPatchAuth = payload.Config.EnableNTPAuth
+
+			// Update the mock state so subsequent GETs reflect the change.
+			if payload.Config.Enabled != nil {
+				if *payload.Config.Enabled {
+					atomic.StoreInt32(&globalEnabled, 1)
+				} else {
+					atomic.StoreInt32(&globalEnabled, 0)
+				}
+			}
+			if payload.Config.EnableNTPAuth != nil {
+				if *payload.Config.EnableNTPAuth {
+					atomic.StoreInt32(&globalAuth, 1)
+				} else {
+					atomic.StoreInt32(&globalAuth, 0)
+				}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			en := atomic.LoadInt32(&globalEnabled) == 1
+			au := atomic.LoadInt32(&globalAuth) == 1
+			w.WriteHeader(http.StatusOK)
+			resp := fmt.Sprintf(`{
+				"openconfig-system:config": {
+					"enabled": %v,
+					"enable-ntp-auth": %v
+				}
+			}`, en, au)
+			_, _ = w.Write([]byte(resp))
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with ntp_service=true, ntp_authentication=true
+			{
+				Config: testUnitNTPServerBasicConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_service", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_authentication", "true"),
+				),
+			},
+			// Step 2: Update to ntp_service=false, ntp_authentication=false
+			{
+				Config: testUnitNTPServerUpdateNTPServiceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_service", "false"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_authentication", "false"),
+					func(_ *terraform.State) error {
+						count := atomic.LoadInt32(&ntpConfigPatchCount)
+						// At least 2: once for Create, once for Update
+						if count < 2 {
+							return fmt.Errorf("expected PATCH /ntp/config to be called at least 2 times (Create + Update), got %d", count)
+						}
+						if lastPatchService == nil || *lastPatchService != false {
+							return fmt.Errorf("expected last PATCH to set enabled=false, got %v", lastPatchService)
+						}
+						if lastPatchAuth == nil || *lastPatchAuth != false {
+							return fmt.Errorf("expected last PATCH to set enable-ntp-auth=false, got %v", lastPatchAuth)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unit test: PatchNTPGlobalConfig is NOT called when ntp_service/ntp_authentication are omitted
+// ---------------------------------------------------------------------------
+
+const testUnitNTPServerNoGlobalConfig = `
+resource "f5os_ntp_server" "test" {
+  server = "10.20.30.40"
+  key_id = 123
+  prefer = true
+  iburst = true
+}
+`
+
+func TestUnitNTPGlobalConfigNotPatchedWhenOmitted(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var ntpConfigPatchCount int32
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers/server=10.20.30.40", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:server": [{
+					"address": "10.20.30.40",
+					"config": {
+						"address": "10.20.30.40",
+						"f5-openconfig-system-ntp:key-id": 123,
+						"prefer": true,
+						"iburst": true
+					}
+				}]
+			}`))
+		case "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			atomic.AddInt32(&ntpConfigPatchCount, 1)
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:config": {
+					"enabled": false,
+					"enable-ntp-auth": false
+				}
+			}`))
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitNTPServerNoGlobalConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "server", "10.20.30.40"),
+					func(_ *terraform.State) error {
+						count := atomic.LoadInt32(&ntpConfigPatchCount)
+						if count != 0 {
+							return fmt.Errorf("expected PATCH /ntp/config to NOT be called when ntp_service/ntp_authentication are omitted, but got %d calls", count)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unit test: key_id=0 is serialized in POST body (not dropped by omitempty)
+//
+// Before the *int64 fix, omitempty treated int64(0) as empty and silently
+// dropped "f5-openconfig-system-ntp:key-id" from the JSON payload.  This
+// test would FAIL with the old code because the POST body would lack key-id.
+// ---------------------------------------------------------------------------
+
+const testUnitNTPServerKeyIDZeroConfig = `
+resource "f5os_ntp_server" "zero" {
+  server             = "10.20.30.41"
+  key_id             = 0
+  prefer             = true
+  iburst             = true
+  ntp_service        = true
+  ntp_authentication = true
+}
+`
+
+func TestUnitNTPServerKeyIDZeroSerialized(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var postBodyKeyID *float64 // float64 because json.Unmarshal decodes numbers as float64
+
+	// Mock: POST to create NTP server — inspect the body for key-id
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			defer func() { _ = r.Body.Close() }()
+			body, _ := io.ReadAll(r.Body)
+
+			// Decode the POST payload to check for key-id
+			var payload struct {
+				Server []struct {
+					Config struct {
+						KeyID *float64 `json:"f5-openconfig-system-ntp:key-id"`
+					} `json:"config"`
+				} `json:"server"`
+			}
+			if err := json.Unmarshal(body, &payload); err == nil && len(payload.Server) > 0 {
+				postBodyKeyID = payload.Server[0].Config.KeyID
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	})
+
+	// Mock: GET/DELETE for specific NTP server — return key-id: 0
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers/server=10.20.30.41", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:server": [{
+					"address": "10.20.30.41",
+					"config": {
+						"address": "10.20.30.41",
+						"f5-openconfig-system-ntp:key-id": 0,
+						"prefer": true,
+						"iburst": true
+					}
+				}]
+			}`))
+		case "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	// Mock: GET/PATCH for global NTP config
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:config": {
+					"enabled": true,
+					"enable-ntp-auth": true
+				}
+			}`))
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitNTPServerKeyIDZeroConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Terraform state must record key_id as "0", not empty
+					resource.TestCheckResourceAttr("f5os_ntp_server.zero", "key_id", "0"),
+					// The POST body must have included key-id: 0
+					func(_ *terraform.State) error {
+						if postBodyKeyID == nil {
+							return fmt.Errorf("POST body did not contain 'f5-openconfig-system-ntp:key-id'; omitempty dropped key_id=0")
+						}
+						if *postBodyKeyID != 0 {
+							return fmt.Errorf("expected key-id=0 in POST body, got %v", *postBodyKeyID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unit test: key_id omitted from config results in no key-id field in payload
+//
+// When the user does NOT set key_id at all, the provider should omit the
+// field from the JSON payload entirely (omitempty with nil *int64).
+// Also verifies the read path handles a GET response that lacks key-id
+// (nil-pointer safety).
+// ---------------------------------------------------------------------------
+
+const testUnitNTPServerKeyIDOmittedConfig = `
+resource "f5os_ntp_server" "nokey" {
+  server             = "10.20.30.42"
+  prefer             = true
+  iburst             = true
+  ntp_service        = true
+  ntp_authentication = true
+}
+`
+
+func TestUnitNTPServerKeyIDOmittedNotSerialized(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var keyIDPresent bool
+
+	// Mock: POST to create NTP server — check that key-id is absent
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			defer func() { _ = r.Body.Close() }()
+			body, _ := io.ReadAll(r.Body)
+
+			// Use a raw map to detect the presence of the key-id field
+			var payload map[string]interface{}
+			if err := json.Unmarshal(body, &payload); err == nil {
+				if servers, ok := payload["server"].([]interface{}); ok && len(servers) > 0 {
+					if srv, ok := servers[0].(map[string]interface{}); ok {
+						if cfg, ok := srv["config"].(map[string]interface{}); ok {
+							_, keyIDPresent = cfg["f5-openconfig-system-ntp:key-id"]
+						}
+					}
+				}
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	})
+
+	// Mock: GET/PATCH/DELETE for specific NTP server — return response WITHOUT key-id
+	// to also exercise the nil-pointer dereference safety in GetNTPServer
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/openconfig-system:servers/server=10.20.30.42", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:server": [{
+					"address": "10.20.30.42",
+					"config": {
+						"address": "10.20.30.42",
+						"prefer": true,
+						"iburst": true
+					}
+				}]
+			}`))
+		case "PATCH":
+			w.WriteHeader(http.StatusNoContent)
+		case "DELETE":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	// Mock: GET/PATCH for global NTP config
+	mux.HandleFunc("/restconf/data/openconfig-system:system/ntp/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"openconfig-system:config": {
+					"enabled": true,
+					"enable-ntp-auth": true
+				}
+			}`))
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitNTPServerKeyIDOmittedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.nokey", "server", "10.20.30.42"),
+					// The POST body must NOT have included key-id
+					func(_ *terraform.State) error {
+						if keyIDPresent {
+							return fmt.Errorf("POST body contained 'f5-openconfig-system-ntp:key-id' even though key_id was not set in the config; expected the field to be omitted")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test (real device)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Acceptance-test HCL configs for NTP global config patching
+// Uses 10.255.255.2 to avoid colliding with the basic NTP acceptance test
+// ---------------------------------------------------------------------------
+
+const testAccNTPGlobalConfigCreateEnabled = `
+resource "f5os_ntp_server" "global" {
+  server             = "10.255.255.2"
+  prefer             = true
+  iburst             = true
+  ntp_service        = true
+  ntp_authentication = true
+}
+`
+
+const testAccNTPGlobalConfigUpdateDisabled = `
+resource "f5os_ntp_server" "global" {
+  server             = "10.255.255.2"
+  prefer             = true
+  iburst             = true
+  ntp_service        = false
+  ntp_authentication = false
+}
+`
+
+const testAccNTPGlobalConfigUpdateReEnabled = `
+resource "f5os_ntp_server" "global" {
+  server             = "10.255.255.2"
+  prefer             = true
+  iburst             = true
+  ntp_service        = true
+  ntp_authentication = true
+}
+`
+
+// ---------------------------------------------------------------------------
+// Acceptance test: PatchNTPGlobalConfig is called on Create and Update
+// ---------------------------------------------------------------------------
+
+func TestAccNTPGlobalConfigPatched(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNTPServerDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with ntp_service=true, ntp_authentication=true
+			//         Verify the global config was actually written to the device.
+			{
+				Config: testAccNTPGlobalConfigCreateEnabled,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Terraform state checks
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "server", "10.255.255.2"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "ntp_service", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "ntp_authentication", "true"),
+					// Direct device API verification
+					testAccCheckNTPServerOnDevice("10.255.255.2", 0, true, true),
+					testAccCheckNTPGlobalConfigOnDevice(true, true),
+				),
+			},
+			// Step 2: Update to ntp_service=false, ntp_authentication=false
+			//         Verify PatchNTPGlobalConfig wrote the change to the device.
+			{
+				Config: testAccNTPGlobalConfigUpdateDisabled,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "ntp_service", "false"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "ntp_authentication", "false"),
+					// Direct device API verification
+					testAccCheckNTPGlobalConfigOnDevice(false, false),
+				),
+			},
+			// Step 3: Update back to ntp_service=true, ntp_authentication=true
+			//         Confirms the toggle works in both directions.
+			{
+				Config: testAccNTPGlobalConfigUpdateReEnabled,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "ntp_service", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.global", "ntp_authentication", "true"),
+					// Direct device API verification
+					testAccCheckNTPGlobalConfigOnDevice(true, true),
+				),
+			},
+			// Step 4: Destroy is automatic — CheckDestroy verifies NTP server cleanup
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test: key_id omitted — verifies the *int64 nil path
+//
+// The key-id field is a YANG leafref that requires a pre-configured NTP
+// authentication key to exist on the device.  Because our test device has no
+// NTP authentication keys, we cannot send key_id=0 or any other value (the
+// device returns "illegal reference").  The key_id=0 serialisation fix is
+// fully covered by TestUnitNTPServerKeyIDZeroSerialized.
+//
+// This acceptance test verifies the *other* half of the *int64 fix: when the
+// user omits key_id, the pointer stays nil and omitempty correctly omits the
+// field from the JSON payload, so the device accepts the request.
+//
+// Uses 10.255.255.3 to avoid colliding with other NTP acceptance tests.
+// ---------------------------------------------------------------------------
+
+const testAccNTPKeyIDOmittedCreate = `
+resource "f5os_ntp_server" "keyid" {
+  server             = "10.255.255.3"
+  prefer             = true
+  iburst             = true
+  ntp_service        = true
+  ntp_authentication = true
+}
+`
+
+func TestAccNTPServerKeyIDOmitted(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNTPServerDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create without key_id — exercises the *int64 nil path.
+			// Before the fix, CreateNTPServerPayload always called
+			// plan.KeyID.ValueInt64() which returned 0, and the old
+			// int64 field would either be omitted (omitempty) or sent
+			// as 0 depending on the code path.  With *int64, when
+			// key_id is not in the config the pointer stays nil and
+			// omitempty correctly omits the field.
+			{
+				Config: testAccNTPKeyIDOmittedCreate,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.keyid", "server", "10.255.255.3"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.keyid", "prefer", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.keyid", "iburst", "true"),
+					// Direct device API verification — key_id defaults to 0
+					testAccCheckNTPServerOnDevice("10.255.255.3", 0, true, true),
+				),
+
+			},
+			// Step 2: Destroy is automatic — CheckDestroy verifies cleanup.
+			// Note: Update steps are intentionally omitted. The NTP server
+			// PATCH (Update) has a pre-existing bug where the POST-style
+			// payload doesn't correctly update prefer/iburst on the device.
+			// That bug is orthogonal to the *int64 fix under test.
+		},
+	})
+}
+
+func TestAccF5osNTPServerResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNTPServerDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create and verify
+			{
+				Config: testAccNTPServerBasicConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Terraform state checks
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "server", "10.255.255.1"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "prefer", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "iburst", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_service", "true"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "ntp_authentication", "true"),
+					// Direct device API verification
+					testAccCheckNTPServerOnDevice("10.255.255.1", 0, true, true),
+					testAccCheckNTPGlobalConfigOnDevice(true, true),
+				),
+			},
+			// Step 2: Import state by server address — verifies ImportState
+			// passes the ID through to the "server" attribute so Read can
+			// query the device and populate all fields.
+			{
+				ResourceName:      "f5os_ntp_server.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Step 3: Update and verify
+			{
+				Config: testAccNTPServerUpdatedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "server", "10.255.255.1"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "prefer", "false"),
+					resource.TestCheckResourceAttr("f5os_ntp_server.test", "iburst", "false"),
+					// Direct device API verification
+					testAccCheckNTPServerOnDevice("10.255.255.1", 0, false, false),
+				),
+			},
+			// Step 4: Destroy is automatic — CheckDestroy verifies cleanup
+		},
+	})
 }

--- a/internal/provider/f5os_snmp_resource.go
+++ b/internal/provider/f5os_snmp_resource.go
@@ -88,6 +88,8 @@ type snmpClient interface {
 	DeleteSnmpTarget(name string) error
 	DeleteSnmpCommunity(name string) error
 	DeleteSnmpUser(name string) error
+	GetSnmpConfig() ([]byte, error)
+	GetSnmpMib() ([]byte, error)
 }
 
 // f5osSnmpClient adapts the concrete SDK client to the snmpClient interface.
@@ -111,6 +113,8 @@ func (a *f5osSnmpClient) UpdateSnmpTargets(payload []byte) error {
 func (a *f5osSnmpClient) DeleteSnmpTarget(name string) error    { return a.c.DeleteSnmpTarget(name) }
 func (a *f5osSnmpClient) DeleteSnmpCommunity(name string) error { return a.c.DeleteSnmpCommunity(name) }
 func (a *f5osSnmpClient) DeleteSnmpUser(name string) error      { return a.c.DeleteSnmpUser(name) }
+func (a *f5osSnmpClient) GetSnmpConfig() ([]byte, error)        { return a.c.GetSnmpConfig() }
+func (a *f5osSnmpClient) GetSnmpMib() ([]byte, error)           { return a.c.GetSnmpMib() }
 
 // NewSnmpResource creates a new instance of the resource
 func NewSnmpResource() resource.Resource {
@@ -127,7 +131,8 @@ func (r *SnmpResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Resource used to manage SNMP configuration (Communities, Users, Targets, and MIB settings) on F5OS systems (VELOS or rSeries).\n\n" +
 			"~> **NOTE:** The `f5os_snmp` resource manages SNMP settings on F5OS platforms using Open API. " +
-			"Due to API restrictions, passwords cannot be retrieved which may lead to Terraform detecting changes on every plan.",
+			"Due to API restrictions, passwords cannot be retrieved which may lead to Terraform detecting changes on every plan.\n\n" +
+			"~> **NOTE:** Running `terraform destroy` will reset MIB fields (sysContact, sysLocation, sysName) to their defaults and remove the resource from Terraform state.",
 		Attributes: map[string]schema.Attribute{
 			"snmp_community": schema.ListNestedAttribute{
 				Optional:            true,
@@ -201,6 +206,9 @@ func (r *SnmpResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 							Optional:            true,
 							Sensitive:           true,
 							MarkdownDescription: "Password for authentication.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"privacy_proto": schema.StringAttribute{
 							Optional:            true,
@@ -210,6 +218,9 @@ func (r *SnmpResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 							Optional:            true,
 							Sensitive:           true,
 							MarkdownDescription: "Password for encryption.",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},
@@ -269,47 +280,6 @@ func (r *SnmpResource) Configure(_ context.Context, req resource.ConfigureReques
 
 	r.client = &f5osSnmpClient{c: client}
 }
-
-// // computeResourceID generates a hash-based ID from SNMP configuration
-// func computeSnmpResourceID(communities []SnmpCommunityModel, targets []SnmpTargetModel, users []SnmpUserModel, mib *SnmpMibModel) string {
-// 	var configParts []string
-
-// 	// Add communities
-// 	for _, community := range communities {
-// 		configParts = append(configParts, fmt.Sprintf("community:%s", community.Name.ValueString()))
-// 	}
-
-// 	// Add targets
-// 	for _, target := range targets {
-// 		configParts = append(configParts, fmt.Sprintf("target:%s", target.Name.ValueString()))
-// 	}
-
-// 	// Add users
-// 	for _, user := range users {
-// 		configParts = append(configParts, fmt.Sprintf("user:%s", user.Name.ValueString()))
-// 	}
-
-// 	// Add MIB
-// 	if mib != nil {
-// 		if !mib.SysName.IsNull() {
-// 			configParts = append(configParts, fmt.Sprintf("mib:sysname:%s", mib.SysName.ValueString()))
-// 		}
-// 		if !mib.SysContact.IsNull() {
-// 			configParts = append(configParts, fmt.Sprintf("mib:syscontact:%s", mib.SysContact.ValueString()))
-// 		}
-// 		if !mib.SysLocation.IsNull() {
-// 			configParts = append(configParts, fmt.Sprintf("mib:syslocation:%s", mib.SysLocation.ValueString()))
-// 		}
-// 	}
-
-// 	// Sort to ensure consistent hash
-// 	sort.Strings(configParts)
-// 	configStr := strings.Join(configParts, ";")
-
-// 	// Generate SHA-256 hash
-// 	hash := sha256.Sum256([]byte(configStr))
-// 	return hex.EncodeToString(hash[:])
-// }
 
 // extractSnmpCommunities safely extracts SNMP communities from a types.List
 func extractSnmpCommunities(ctx context.Context, list types.List) ([]SnmpCommunityModel, diag.Diagnostics) {
@@ -426,7 +396,7 @@ func (r *SnmpResource) Create(ctx context.Context, req resource.CreateRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-// Read refreshes the Terraform state with the latest data
+// Read refreshes the Terraform state with the latest data from the device.
 func (r *SnmpResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state SnmpResourceModel
 
@@ -438,25 +408,271 @@ func (r *SnmpResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	tflog.Info(ctx, "Reading SNMP configuration from F5OS")
 
-	// IMPORTANT: The resource ID must never be changed in Read to prevent Terraform state drift and test failures.
-	// During import, the state field might be empty, so we need to set it
-	// For SNMP configuration resources, we assume the state is "present" if the resource exists
-	if state.State.IsNull() || state.State.IsUnknown() {
-		state.State = types.StringValue("present")
-	}
-	// Always use the static resource ID
+	// Always use the static resource ID and present state.
 	state.Id = types.StringValue("snmp_config")
+	state.State = types.StringValue("present")
 
-	// For now, we'll keep the existing state as SNMP config reading is complex
-	// This is a common pattern for configuration resources where the API doesn't
-	// provide complete read capabilities, especially for sensitive data like passwords
+	// ------------------------------------------------------------------
+	// 1. Read SNMP communities, targets, and users from the device.
+	// ------------------------------------------------------------------
+	snmpData, err := r.client.GetSnmpConfig()
+	if err != nil {
+		resp.Diagnostics.AddError("SNMP Read Error", fmt.Sprintf("Failed to read SNMP config from device: %s", err))
+		return
+	}
+
+	var snmpEnvelope struct {
+		SNMP struct {
+			Communities struct {
+				Community []struct {
+					Name   string `json:"name"`
+					Config struct {
+						Name          string   `json:"name"`
+						SecurityModel []string `json:"security-model"`
+					} `json:"config"`
+				} `json:"community"`
+			} `json:"communities"`
+			Targets struct {
+				Target []struct {
+					Name   string `json:"name"`
+					Config struct {
+						Name          string `json:"name"`
+						SecurityModel string `json:"security-model"`
+						Community     string `json:"community"`
+						User          string `json:"user"`
+						IPv4          *struct {
+							Address string `json:"address"`
+							Port    int64  `json:"port"`
+						} `json:"ipv4"`
+						IPv6 *struct {
+							Address string `json:"address"`
+							Port    int64  `json:"port"`
+						} `json:"ipv6"`
+					} `json:"config"`
+				} `json:"target"`
+			} `json:"targets"`
+			Users struct {
+				User []struct {
+					Name   string `json:"name"`
+					Config struct {
+						Name                   string `json:"name"`
+						AuthenticationProtocol string `json:"authentication-protocol"`
+						PrivacyProtocol        string `json:"privacy-protocol"`
+					} `json:"config"`
+				} `json:"user"`
+			} `json:"users"`
+		} `json:"f5-system-snmp:snmp"`
+	}
+
+	if err := json.Unmarshal(snmpData, &snmpEnvelope); err != nil {
+		resp.Diagnostics.AddError("SNMP Parse Error", fmt.Sprintf("Failed to parse SNMP config JSON: %s", err))
+		return
+	}
+
+	// Build lookups from the prior state so we know which entries are managed
+	// by this resource and can preserve sensitive fields the API won't return.
+	oldCommunities, diags := extractSnmpCommunities(ctx, state.SnmpCommunity)
+	resp.Diagnostics.Append(diags...)
+	oldTargets, diags := extractSnmpTargets(ctx, state.SnmpTarget)
+	resp.Diagnostics.Append(diags...)
+	oldUsers, diags := extractSnmpUsers(ctx, state.SnmpUser)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// When the prior state has entries, Read should only track the entries
+	// that Terraform manages (i.e., those names present in state).
+	// When the prior state is empty/null (e.g., after import), Read imports
+	// everything from the device.
+	managedCommunities := make(map[string]bool)
+	for _, c := range oldCommunities {
+		managedCommunities[c.Name.ValueString()] = true
+	}
+	managedTargets := make(map[string]bool)
+	for _, t := range oldTargets {
+		managedTargets[t.Name.ValueString()] = true
+	}
+	managedUsers := make(map[string]bool)
+	for _, u := range oldUsers {
+		managedUsers[u.Name.ValueString()] = true
+	}
+	userPasswords := make(map[string][2]types.String) // name -> {auth_passwd, privacy_passwd}
+	for _, u := range oldUsers {
+		userPasswords[u.Name.ValueString()] = [2]types.String{u.AuthPasswd, u.PrivacyPasswd}
+	}
+
+	filterCommunities := len(managedCommunities) > 0
+	filterTargets := len(managedTargets) > 0
+	filterUsers := len(managedUsers) > 0
+
+	// --- Communities ---
+	snmpCommunities := snmpEnvelope.SNMP.Communities.Community
+	{
+		communityObjects := make([]SnmpCommunityModel, 0, len(snmpCommunities))
+		for _, c := range snmpCommunities {
+			if filterCommunities && !managedCommunities[c.Config.Name] {
+				continue
+			}
+			smVals := make([]attr.Value, 0, len(c.Config.SecurityModel))
+			for _, sm := range c.Config.SecurityModel {
+				smVals = append(smVals, types.StringValue(sm))
+			}
+			smList, listDiags := types.ListValue(types.StringType, smVals)
+			resp.Diagnostics.Append(listDiags...)
+			communityObjects = append(communityObjects, SnmpCommunityModel{
+				Name:          types.StringValue(c.Config.Name),
+				SecurityModel: smList,
+			})
+		}
+		if len(communityObjects) > 0 {
+			communityList, listDiags := types.ListValueFrom(ctx, state.SnmpCommunity.ElementType(ctx), communityObjects)
+			resp.Diagnostics.Append(listDiags...)
+			state.SnmpCommunity = communityList
+		} else if !state.SnmpCommunity.IsNull() {
+			state.SnmpCommunity = types.ListNull(state.SnmpCommunity.ElementType(ctx))
+		}
+	}
+
+	// --- Targets ---
+	snmpTargets := snmpEnvelope.SNMP.Targets.Target
+	{
+		targetObjects := make([]SnmpTargetModel, 0, len(snmpTargets))
+		for _, t := range snmpTargets {
+			if filterTargets && !managedTargets[t.Config.Name] {
+				continue
+			}
+			tm := SnmpTargetModel{
+				Name: types.StringValue(t.Config.Name),
+			}
+			if t.Config.SecurityModel != "" {
+				tm.SecurityModel = types.StringValue(t.Config.SecurityModel)
+			} else {
+				tm.SecurityModel = types.StringNull()
+			}
+			if t.Config.Community != "" {
+				tm.Community = types.StringValue(t.Config.Community)
+			} else {
+				tm.Community = types.StringNull()
+			}
+			if t.Config.User != "" {
+				tm.User = types.StringValue(t.Config.User)
+			} else {
+				tm.User = types.StringNull()
+			}
+			switch {
+			case t.Config.IPv4 != nil:
+				tm.Ipv4Address = types.StringValue(t.Config.IPv4.Address)
+				tm.Port = types.Int64Value(t.Config.IPv4.Port)
+				tm.Ipv6Address = types.StringNull()
+			case t.Config.IPv6 != nil:
+				tm.Ipv6Address = types.StringValue(t.Config.IPv6.Address)
+				tm.Port = types.Int64Value(t.Config.IPv6.Port)
+				tm.Ipv4Address = types.StringNull()
+			default:
+				tm.Ipv4Address = types.StringNull()
+				tm.Ipv6Address = types.StringNull()
+				tm.Port = types.Int64Value(0)
+			}
+			targetObjects = append(targetObjects, tm)
+		}
+		if len(targetObjects) > 0 {
+			targetList, listDiags := types.ListValueFrom(ctx, state.SnmpTarget.ElementType(ctx), targetObjects)
+			resp.Diagnostics.Append(listDiags...)
+			state.SnmpTarget = targetList
+		} else if !state.SnmpTarget.IsNull() {
+			state.SnmpTarget = types.ListNull(state.SnmpTarget.ElementType(ctx))
+		}
+	}
+
+	// --- Users ---
+	snmpUsers := snmpEnvelope.SNMP.Users.User
+	{
+		userObjects := make([]SnmpUserModel, 0, len(snmpUsers))
+		for _, u := range snmpUsers {
+			if filterUsers && !managedUsers[u.Config.Name] {
+				continue
+			}
+			um := SnmpUserModel{
+				Name: types.StringValue(u.Config.Name),
+			}
+			if u.Config.AuthenticationProtocol != "" {
+				um.AuthProto = types.StringValue(u.Config.AuthenticationProtocol)
+			} else {
+				um.AuthProto = types.StringNull()
+			}
+			if u.Config.PrivacyProtocol != "" {
+				um.PrivacyProto = types.StringValue(u.Config.PrivacyProtocol)
+			} else {
+				um.PrivacyProto = types.StringNull()
+			}
+			// Passwords are never returned by the API. Preserve prior state values.
+			if pw, ok := userPasswords[u.Config.Name]; ok {
+				um.AuthPasswd = pw[0]
+				um.PrivacyPasswd = pw[1]
+			} else {
+				um.AuthPasswd = types.StringNull()
+				um.PrivacyPasswd = types.StringNull()
+			}
+			userObjects = append(userObjects, um)
+		}
+		if len(userObjects) > 0 {
+			userList, listDiags := types.ListValueFrom(ctx, state.SnmpUser.ElementType(ctx), userObjects)
+			resp.Diagnostics.Append(listDiags...)
+			state.SnmpUser = userList
+		} else if !state.SnmpUser.IsNull() {
+			state.SnmpUser = types.ListNull(state.SnmpUser.ElementType(ctx))
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// 2. Read MIB settings from the device.
+	// Only populate snmp_mib in state if the user is managing it (i.e.,
+	// the prior state had snmp_mib set). If snmp_mib was null, the user
+	// did not declare it and we should not pull device-global MIB values
+	// into state — that would cause spurious diffs.
+	// ------------------------------------------------------------------
+	mibWasManaged := !state.SnmpMib.IsNull()
+
+	mibData, err := r.client.GetSnmpMib()
+	if err != nil {
+		// MIB read failure is non-fatal; leave snmp_mib unchanged.
+		tflog.Warn(ctx, "Failed to read SNMP MIB from device", map[string]interface{}{"error": err.Error()})
+	} else if mibWasManaged {
+		var mibEnvelope struct {
+			System struct {
+				SysName     string `json:"sysName"`
+				SysContact  string `json:"sysContact"`
+				SysLocation string `json:"sysLocation"`
+			} `json:"SNMPv2-MIB:system"`
+		}
+		if err := json.Unmarshal(mibData, &mibEnvelope); err != nil {
+			tflog.Warn(ctx, "Failed to parse SNMP MIB JSON", map[string]interface{}{"error": err.Error()})
+		} else {
+			mibModel := SnmpMibModel{
+				SysName:     types.StringValue(mibEnvelope.System.SysName),
+				SysContact:  types.StringValue(mibEnvelope.System.SysContact),
+				SysLocation: types.StringValue(mibEnvelope.System.SysLocation),
+			}
+			mibObj, objDiags := types.ObjectValueFrom(ctx, map[string]attr.Type{
+				"sysname":     types.StringType,
+				"syscontact":  types.StringType,
+				"syslocation": types.StringType,
+			}, mibModel)
+			resp.Diagnostics.Append(objDiags...)
+			state.SnmpMib = mibObj
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Debug(ctx, "SNMP configuration read completed", map[string]interface{}{
 		"id":    state.Id.ValueString(),
 		"state": state.State.ValueString(),
 	})
 
-	// Save current state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -492,7 +708,7 @@ func (r *SnmpResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	state := plan.State.ValueString()
 	if state == "absent" {
 		// If state is absent, we should remove the configuration
-		if err := r.deleteSnmpConfig(ctx, communities, targets, users); err != nil {
+		if err := r.deleteSnmpConfig(ctx, communities, targets, users, mib != nil); err != nil {
 			resp.Diagnostics.AddError(
 				"SNMP Configuration Error",
 				fmt.Sprintf("Failed to remove SNMP configuration: %s", err),
@@ -552,8 +768,11 @@ func (r *SnmpResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
+	// Only reset MIB fields if the user actually managed them.
+	resetMib := !state.SnmpMib.IsNull()
+
 	// Delete SNMP configuration
-	if err := r.deleteSnmpConfig(ctx, communities, targets, users); err != nil {
+	if err := r.deleteSnmpConfig(ctx, communities, targets, users, resetMib); err != nil {
 		resp.Diagnostics.AddError(
 			"SNMP Deletion Error",
 			fmt.Sprintf("Failed to delete SNMP configuration: %s", err),
@@ -708,8 +927,11 @@ func (r *SnmpResource) updateSnmpConfig(ctx context.Context, communities []SnmpC
 	return nil
 }
 
-// deleteSnmpConfig handles the deletion of SNMP configuration
-func (r *SnmpResource) deleteSnmpConfig(ctx context.Context, communities []SnmpCommunityModel, targets []SnmpTargetModel, users []SnmpUserModel) error {
+// deleteSnmpConfig handles the deletion of SNMP configuration.
+// When resetMib is true the MIB sysName/sysContact/sysLocation fields are
+// reset to empty strings on the device. Pass false when the user never
+// declared snmp_mib so we don't wipe device-level values they don't own.
+func (r *SnmpResource) deleteSnmpConfig(ctx context.Context, communities []SnmpCommunityModel, targets []SnmpTargetModel, users []SnmpUserModel, resetMib bool) error {
 	// Delete targets first (they may depend on communities/users)
 	for _, target := range targets {
 		err := r.client.DeleteSnmpTarget(target.Name.ValueString())
@@ -740,6 +962,24 @@ func (r *SnmpResource) deleteSnmpConfig(ctx context.Context, communities []SnmpC
 				"user":  user.Name.ValueString(),
 				"error": err.Error(),
 			})
+		}
+	}
+
+	// Only reset MIB fields when the user declared snmp_mib in their config.
+	// Otherwise we would wipe device-level values the user never claimed.
+	if resetMib {
+		emptyMib := map[string]interface{}{
+			"SNMPv2-MIB:system": map[string]interface{}{
+				"SNMPv2-MIB:sysContact":  "",
+				"SNMPv2-MIB:sysName":     "",
+				"SNMPv2-MIB:sysLocation": "",
+			},
+		}
+		mibBytes, err := json.Marshal(emptyMib)
+		if err != nil {
+			tflog.Warn(ctx, "Failed to marshal empty MIB payload", map[string]interface{}{"error": err.Error()})
+		} else if err := r.client.UpdateSnmpMib(mibBytes); err != nil {
+			tflog.Warn(ctx, "Failed to reset SNMP MIB on delete", map[string]interface{}{"error": err.Error()})
 		}
 	}
 

--- a/internal/provider/f5os_snmp_resource_test.go
+++ b/internal/provider/f5os_snmp_resource_test.go
@@ -3,14 +3,41 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
+
+// newSnmpClientFromEnv creates a fresh f5osclient session from environment variables.
+// Port defaults to 8888 to match the provider (provider.go:104).
+func newSnmpClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888 // Must default to 8888 to match the provider
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
 
 func TestAccSnmpResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -33,13 +60,17 @@ func TestAccSnmpResource(t *testing.T) {
 				),
 			},
 			// ImportState testing
+			// Read now queries the device and returns ALL communities, targets,
+			// users, and MIB settings — not just the ones Terraform manages.
+			// The nested blocks must be ignored because the device contains
+			// pre-existing entries beyond what this test created.
+			// Passwords (auth_passwd, privacy_passwd) are also never returned
+			// by the API.
 			{
 				ResourceName:      "f5os_snmp.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"snmp_user.0.auth_passwd",
-					"snmp_user.0.privacy_passwd",
 					"snmp_community",
 					"snmp_target",
 					"snmp_user",
@@ -63,41 +94,10 @@ func TestAccSnmpResource(t *testing.T) {
 
 // testAccCheckSnmpDestroy verifies SNMP config is removed on the device
 func testAccCheckSnmpDestroy(s *terraform.State) error {
-	host := os.Getenv("F5OS_HOST")
-	if host == "" {
+	if os.Getenv("F5OS_HOST") == "" {
 		return nil
 	}
-	user := os.Getenv("F5OS_USERNAME")
-	if user == "" {
-		user = os.Getenv("F5OS_USER")
-	}
-	pass := os.Getenv("F5OS_PASSWORD")
-	port := 0
-	if p := os.Getenv("F5OS_SERVER_PORT"); p != "" {
-		if v, err := strconv.Atoi(p); err == nil {
-			port = v
-		}
-	} else if p := os.Getenv("F5OS_PORT"); p != "" {
-		if v, err := strconv.Atoi(p); err == nil {
-			port = v
-		}
-	}
-	disableSSL := false
-	if v := os.Getenv("F5_VALIDATE_CERTS"); v != "" {
-		// F5_VALIDATE_CERTS=false => DisableSSLVerify=true
-		if v == "false" || v == "0" {
-			disableSSL = true
-		}
-	}
-
-	cfg := &f5ossdk.F5osConfig{
-		Host:             host,
-		User:             user,
-		Password:         pass,
-		Port:             port,
-		DisableSSLVerify: disableSSL,
-	}
-	client, err := f5ossdk.NewSession(cfg)
+	client, err := newSnmpClientFromEnv()
 	if err != nil {
 		// If we cannot connect, don't fail the destroy check
 		return nil
@@ -160,6 +160,709 @@ func jsonContainsAnyName(v interface{}, names []string) bool {
 	}
 	return false
 }
+
+// ---------------------------------------------------------------------------
+// Direct-API verification helpers
+// ---------------------------------------------------------------------------
+
+// testAccCheckSnmpCommunityOnDevice verifies a named community exists on the
+// device with the expected security models.
+func testAccCheckSnmpCommunityOnDevice(name string, securityModels ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSnmpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create SNMP client: %w", err)
+		}
+		data, err := client.GetSnmpConfig()
+		if err != nil {
+			return fmt.Errorf("GetSnmpConfig failed: %w", err)
+		}
+		var envelope struct {
+			SNMP struct {
+				Communities struct {
+					Community []struct {
+						Name   string `json:"name"`
+						Config struct {
+							SecurityModel []string `json:"security-model"`
+						} `json:"config"`
+					} `json:"community"`
+				} `json:"communities"`
+			} `json:"f5-system-snmp:snmp"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("failed to parse SNMP config: %w", err)
+		}
+		for _, c := range envelope.SNMP.Communities.Community {
+			if c.Name != name {
+				continue
+			}
+			// Verify each expected security model is present
+			got := strings.Join(c.Config.SecurityModel, ",")
+			for _, sm := range securityModels {
+				found := false
+				for _, actual := range c.Config.SecurityModel {
+					if actual == sm {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("community %q: expected security-model %q in %q", name, sm, got)
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("community %q not found on device", name)
+	}
+}
+
+// testAccCheckSnmpTargetOnDevice verifies a named trap target exists on the
+// device with the expected IPv4 address and port.
+func testAccCheckSnmpTargetOnDevice(name, ipv4 string, port int64) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSnmpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create SNMP client: %w", err)
+		}
+		data, err := client.GetSnmpConfig()
+		if err != nil {
+			return fmt.Errorf("GetSnmpConfig failed: %w", err)
+		}
+		var envelope struct {
+			SNMP struct {
+				Targets struct {
+					Target []struct {
+						Name   string `json:"name"`
+						Config struct {
+							IPv4 *struct {
+								Address string `json:"address"`
+								Port    int64  `json:"port"`
+							} `json:"ipv4"`
+						} `json:"config"`
+					} `json:"target"`
+				} `json:"targets"`
+			} `json:"f5-system-snmp:snmp"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("failed to parse SNMP config: %w", err)
+		}
+		for _, t := range envelope.SNMP.Targets.Target {
+			if t.Name != name {
+				continue
+			}
+			if t.Config.IPv4 == nil {
+				return fmt.Errorf("target %q: no ipv4 config on device", name)
+			}
+			if t.Config.IPv4.Address != ipv4 {
+				return fmt.Errorf("target %q: expected ipv4 %q, got %q", name, ipv4, t.Config.IPv4.Address)
+			}
+			if t.Config.IPv4.Port != port {
+				return fmt.Errorf("target %q: expected port %d, got %d", name, port, t.Config.IPv4.Port)
+			}
+			return nil
+		}
+		return fmt.Errorf("target %q not found on device", name)
+	}
+}
+
+// testAccCheckSnmpUserOnDevice verifies a named SNMPv3 user exists on the
+// device with the expected authentication and privacy protocols.
+func testAccCheckSnmpUserOnDevice(name, authProto, privacyProto string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSnmpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create SNMP client: %w", err)
+		}
+		data, err := client.GetSnmpConfig()
+		if err != nil {
+			return fmt.Errorf("GetSnmpConfig failed: %w", err)
+		}
+		var envelope struct {
+			SNMP struct {
+				Users struct {
+					User []struct {
+						Name   string `json:"name"`
+						Config struct {
+							AuthProto    string `json:"authentication-protocol"`
+							PrivacyProto string `json:"privacy-protocol"`
+						} `json:"config"`
+					} `json:"user"`
+				} `json:"users"`
+			} `json:"f5-system-snmp:snmp"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("failed to parse SNMP config: %w", err)
+		}
+		for _, u := range envelope.SNMP.Users.User {
+			if u.Name != name {
+				continue
+			}
+			if !strings.EqualFold(u.Config.AuthProto, authProto) {
+				return fmt.Errorf("user %q: expected auth-proto %q, got %q", name, authProto, u.Config.AuthProto)
+			}
+			if !strings.EqualFold(u.Config.PrivacyProto, privacyProto) {
+				return fmt.Errorf("user %q: expected privacy-proto %q, got %q", name, privacyProto, u.Config.PrivacyProto)
+			}
+			return nil
+		}
+		return fmt.Errorf("user %q not found on device", name)
+	}
+}
+
+// testAccCheckSnmpMibOnDevice verifies the SNMP MIB sysName, sysContact, and
+// sysLocation values on the device.
+func testAccCheckSnmpMibOnDevice(sysName, sysContact, sysLocation string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSnmpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create SNMP client: %w", err)
+		}
+		data, err := client.GetSnmpMib()
+		if err != nil {
+			return fmt.Errorf("GetSnmpMib failed: %w", err)
+		}
+		var envelope struct {
+			System struct {
+				SysName     string `json:"sysName"`
+				SysContact  string `json:"sysContact"`
+				SysLocation string `json:"sysLocation"`
+			} `json:"SNMPv2-MIB:system"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("failed to parse SNMP MIB: %w", err)
+		}
+		if envelope.System.SysName != sysName {
+			return fmt.Errorf("sysName: expected %q, got %q", sysName, envelope.System.SysName)
+		}
+		if envelope.System.SysContact != sysContact {
+			return fmt.Errorf("sysContact: expected %q, got %q", sysContact, envelope.System.SysContact)
+		}
+		if envelope.System.SysLocation != sysLocation {
+			return fmt.Errorf("sysLocation: expected %q, got %q", sysLocation, envelope.System.SysLocation)
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestAccSnmpResourceRead — verifies Read populates state from the device
+// ---------------------------------------------------------------------------
+
+// TestAccSnmpResourceRead verifies that:
+//   - After Create, Terraform state reflects what is on the device (community
+//     security_model, target ipv4/port, user auth/privacy protos, MIB fields).
+//   - Read correctly filters state to only the entries Terraform manages —
+//     pre-existing device entries are not pulled into state.
+//   - After Update, both old and new entries appear in state and on the device.
+func TestAccSnmpResourceRead(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSnmpDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create — verify both Terraform state AND device state.
+			{
+				Config: testAccSnmpResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// --- Terraform state assertions ---
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_community.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_community.0.name", "test_community"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_community.0.security_model.#", "2"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.0.name", "test_target"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.0.ipv4_address", "192.168.1.100"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.0.port", "162"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.name", "test_user"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.auth_proto", "sha"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.privacy_proto", "aes"),
+					// Passwords must be present in state (preserved via Computed+UseStateForUnknown)
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.auth_passwd", "testpassword123"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.privacy_passwd", "privacypassword123"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_mib.sysname", "F5OS-Test-System"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_mib.syscontact", "admin@example.com"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_mib.syslocation", "Test Lab"),
+					// --- Direct device API assertions ---
+					testAccCheckSnmpCommunityOnDevice("test_community", "v1", "v2c"),
+					testAccCheckSnmpTargetOnDevice("test_target", "192.168.1.100", 162),
+					testAccCheckSnmpUserOnDevice("test_user", "sha", "aes"),
+					testAccCheckSnmpMibOnDevice("F5OS-Test-System", "admin@example.com", "Test Lab"),
+				),
+			},
+			// Step 2: Update — verify second community/target appear in both
+			// state and on the device; original entry still present.
+			{
+				Config: testAccSnmpResourceConfigUpdated,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// --- Terraform state assertions ---
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_community.#", "2"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.#", "2"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_mib.sysname", "F5OS-Test-System-Updated"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_mib.syscontact", "admin@updated.example.com"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_mib.syslocation", "Updated Test Lab"),
+					// Passwords still in state after update (UseStateForUnknown preserved them)
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.auth_passwd", "testpassword123"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_user.0.privacy_passwd", "privacypassword123"),
+					// --- Direct device API assertions ---
+					testAccCheckSnmpCommunityOnDevice("test_community", "v1", "v2c"),
+					testAccCheckSnmpCommunityOnDevice("test_community2", "v2c"),
+					testAccCheckSnmpTargetOnDevice("test_target", "192.168.1.100", 162),
+					testAccCheckSnmpTargetOnDevice("test_target2", "192.168.1.101", 162),
+					testAccCheckSnmpMibOnDevice("F5OS-Test-System-Updated", "admin@updated.example.com", "Updated Test Lab"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestAccSnmpResourceReadFiltersToManagedEntries — verifies Read does not
+// import pre-existing device entries into Terraform state
+// ---------------------------------------------------------------------------
+
+// TestAccSnmpResourceReadFiltersToManagedEntries verifies that Read only
+// tracks the entries that Terraform created, not the full device config.
+// It asserts the state contains exactly the managed entries (1 community,
+// 1 target) and not any of the pre-existing device communities/targets.
+func TestAccSnmpResourceReadFiltersToManagedEntries(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSnmpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnmpResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Exactly 1 community in state — not the device's pre-existing ones
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_community.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_community.0.name", "test_community"),
+					// Exactly 1 target in state — not the device's pre-existing ones
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.test", "snmp_target.0.name", "test_target"),
+					// Verify pre-existing device entries are NOT in state
+					testAccCheckSnmpStateDoesNotContainCommunity("f5os_snmp.test", "community1"),
+					testAccCheckSnmpStateDoesNotContainCommunity("f5os_snmp.test", "community2"),
+					testAccCheckSnmpStateDoesNotContainTarget("f5os_snmp.test", "Chamo_PC"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckSnmpStateDoesNotContainCommunity asserts that no entry in the
+// snmp_community list in Terraform state has the given name.
+func testAccCheckSnmpStateDoesNotContainCommunity(resourceName, communityName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+		countStr := rs.Primary.Attributes["snmp_community.#"]
+		count, _ := strconv.Atoi(countStr)
+		for i := 0; i < count; i++ {
+			key := fmt.Sprintf("snmp_community.%d.name", i)
+			if rs.Primary.Attributes[key] == communityName {
+				return fmt.Errorf("pre-existing community %q found in Terraform state — Read is not filtering correctly", communityName)
+			}
+		}
+		return nil
+	}
+}
+
+// testAccCheckSnmpStateDoesNotContainTarget asserts that no entry in the
+// snmp_target list in Terraform state has the given name.
+func testAccCheckSnmpStateDoesNotContainTarget(resourceName, targetName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+		countStr := rs.Primary.Attributes["snmp_target.#"]
+		count, _ := strconv.Atoi(countStr)
+		for i := 0; i < count; i++ {
+			key := fmt.Sprintf("snmp_target.%d.name", i)
+			if rs.Primary.Attributes[key] == targetName {
+				return fmt.Errorf("pre-existing target %q found in Terraform state — Read is not filtering correctly", targetName)
+			}
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit test: verifies Read preserves null snmp_mib when the user did not
+// declare it in the HCL config (mibWasManaged guard).
+// ---------------------------------------------------------------------------
+
+const testUnitSnmpNoMibConfig = `
+resource "f5os_snmp" "nomib" {
+  state = "present"
+
+  snmp_community = [
+    {
+      name           = "unit_community"
+      security_model = ["v2c"]
+    }
+  ]
+
+  snmp_target = [
+    {
+      name           = "unit_target"
+      security_model = "v2c"
+      community      = "unit_community"
+      ipv4_address   = "192.168.1.200"
+      port           = 162
+    }
+  ]
+}
+`
+
+func TestUnitSnmpReadPreservesNullMib(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	// Mock: SNMP config — POST for communities/targets/users
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-snmp:snmp/f5-system-snmp:communities", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-snmp:snmp/f5-system-snmp:targets", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-snmp:snmp/f5-system-snmp:users", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Mock: GET SNMP config — returns the community and target we created
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-snmp:snmp", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"f5-system-snmp:snmp": {
+					"communities": {
+						"community": [
+							{
+								"name": "unit_community",
+								"config": {
+									"name": "unit_community",
+									"security-model": ["v2c"]
+								}
+							}
+						]
+					},
+					"targets": {
+						"target": [
+							{
+								"name": "unit_target",
+								"config": {
+									"name": "unit_target",
+									"security-model": "v2c",
+									"community": "unit_community",
+									"ipv4": {
+										"address": "192.168.1.200",
+										"port": 162
+									}
+								}
+							}
+						]
+					}
+				}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	// Mock: GET SNMP MIB — returns real values, but they should NOT
+	// appear in state because snmp_mib is not declared in the config.
+	mux.HandleFunc("/restconf/data/SNMPv2-MIB:SNMPv2-MIB/system", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"SNMPv2-MIB:system": {
+				"sysName": "DeviceThatShouldNotAppear",
+				"sysContact": "admin@should-not-appear.com",
+				"sysLocation": "Nowhere"
+			}
+		}`))
+	})
+
+	// Mock: DELETE endpoints for destroy
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-snmp:snmp/targets/target=unit_target", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-snmp:snmp/communities/community=unit_community", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitSnmpNoMibConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Community and target should be in state
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_community.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_community.0.name", "unit_community"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.0.name", "unit_target"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.0.ipv4_address", "192.168.1.200"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.0.port", "162"),
+
+					// snmp_mib must NOT be populated — the user didn't
+					// declare it and the mibWasManaged guard should keep
+					// it null even though the mock returns MIB data.
+					resource.TestCheckNoResourceAttr("f5os_snmp.nomib", "snmp_mib.sysname"),
+					resource.TestCheckNoResourceAttr("f5os_snmp.nomib", "snmp_mib.syscontact"),
+					resource.TestCheckNoResourceAttr("f5os_snmp.nomib", "snmp_mib.syslocation"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestAccSnmpResourceMibNotManaged — acceptance test for the mibWasManaged
+// guard: when snmp_mib is omitted from the HCL config, Read must not
+// populate it from the device even though the device has global MIB values.
+// ---------------------------------------------------------------------------
+
+// testAccCheckSnmpMibAbsentFromState asserts that snmp_mib is not set in
+// Terraform state (i.e., all MIB sub-attributes are absent).
+func testAccCheckSnmpMibAbsentFromState(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckNoResourceAttr(resourceName, "snmp_mib.sysname"),
+		resource.TestCheckNoResourceAttr(resourceName, "snmp_mib.syscontact"),
+		resource.TestCheckNoResourceAttr(resourceName, "snmp_mib.syslocation"),
+	)
+}
+
+const testAccSnmpNoMibConfig = `
+resource "f5os_snmp" "nomib" {
+  state = "present"
+
+  snmp_community = [
+    {
+      name           = "test_nomib_community"
+      security_model = ["v2c"]
+    }
+  ]
+
+  snmp_target = [
+    {
+      name           = "test_nomib_target"
+      security_model = "v2c"
+      community      = "test_nomib_community"
+      ipv4_address   = "192.168.1.200"
+      port           = 162
+    }
+  ]
+}
+`
+
+func TestAccSnmpResourceMibNotManaged(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSnmpDestroy,
+		Steps: []resource.TestStep{
+			// Create SNMP config WITHOUT snmp_mib.
+			// After Read, snmp_mib must remain null in state even though
+			// the device has global MIB values — the mibWasManaged guard
+			// must suppress them.
+			{
+				Config: testAccSnmpNoMibConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Community and target written and read back correctly
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_community.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_community.0.name", "test_nomib_community"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.#", "1"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.0.name", "test_nomib_target"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.0.ipv4_address", "192.168.1.200"),
+					resource.TestCheckResourceAttr("f5os_snmp.nomib", "snmp_target.0.port", "162"),
+
+					// snmp_mib must NOT be populated — the user didn't
+					// declare it and the device's global MIB values must
+					// not leak into Terraform state.
+					testAccCheckSnmpMibAbsentFromState("f5os_snmp.nomib"),
+
+					// Confirm community and target exist on the device
+					testAccCheckSnmpCommunityOnDevice("test_nomib_community", "v2c"),
+					testAccCheckSnmpTargetOnDevice("test_nomib_target", "192.168.1.200", 162),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestAccSnmpResourceDeleteResetsMib — verifies that terraform destroy resets
+// MIB sysName/sysContact/sysLocation to empty strings instead of leaving
+// orphaned values on the device.
+// Captures the device baseline MIB before the test and restores it via
+// a deferred cleanup.
+// ---------------------------------------------------------------------------
+
+// snmpMibBaseline holds the original MIB values to restore after the test.
+type snmpMibBaseline struct {
+	SysName     string
+	SysContact  string
+	SysLocation string
+}
+
+// captureSnmpMibBaseline reads the current MIB values from the device.
+func captureSnmpMibBaseline() (*snmpMibBaseline, error) {
+	client, err := newSnmpClientFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	data, err := client.GetSnmpMib()
+	if err != nil {
+		return nil, fmt.Errorf("GetSnmpMib failed: %w", err)
+	}
+	var envelope struct {
+		System struct {
+			SysName     string `json:"sysName"`
+			SysContact  string `json:"sysContact"`
+			SysLocation string `json:"sysLocation"`
+		} `json:"SNMPv2-MIB:system"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to parse MIB: %w", err)
+	}
+	return &snmpMibBaseline{
+		SysName:     envelope.System.SysName,
+		SysContact:  envelope.System.SysContact,
+		SysLocation: envelope.System.SysLocation,
+	}, nil
+}
+
+// restoreSnmpMibBaseline writes the captured baseline MIB values back to the device.
+func restoreSnmpMibBaseline(b *snmpMibBaseline) error {
+	client, err := newSnmpClientFromEnv()
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	payload := map[string]interface{}{
+		"SNMPv2-MIB:system": map[string]interface{}{
+			"SNMPv2-MIB:sysName":     b.SysName,
+			"SNMPv2-MIB:sysContact":  b.SysContact,
+			"SNMPv2-MIB:sysLocation": b.SysLocation,
+		},
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal MIB payload: %w", err)
+	}
+	return client.UpdateSnmpMib(payloadBytes)
+}
+
+// testAccCheckSnmpMibResetOnDevice verifies that after destroy, all three
+// MIB fields are empty strings on the device.
+func testAccCheckSnmpMibResetOnDevice() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSnmpClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		data, err := client.GetSnmpMib()
+		if err != nil {
+			return fmt.Errorf("GetSnmpMib failed: %w", err)
+		}
+		var envelope struct {
+			System struct {
+				SysName     string `json:"sysName"`
+				SysContact  string `json:"sysContact"`
+				SysLocation string `json:"sysLocation"`
+			} `json:"SNMPv2-MIB:system"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("failed to parse MIB: %w", err)
+		}
+		if envelope.System.SysName != "" {
+			return fmt.Errorf("sysName should be empty after destroy, got %q", envelope.System.SysName)
+		}
+		if envelope.System.SysContact != "" {
+			return fmt.Errorf("sysContact should be empty after destroy, got %q", envelope.System.SysContact)
+		}
+		if envelope.System.SysLocation != "" {
+			return fmt.Errorf("sysLocation should be empty after destroy, got %q", envelope.System.SysLocation)
+		}
+		return nil
+	}
+}
+
+const testAccSnmpMibResetConfig = `
+resource "f5os_snmp" "mib_reset" {
+  state = "present"
+
+  snmp_community = [
+    {
+      name           = "test_mib_reset_community"
+      security_model = ["v2c"]
+    }
+  ]
+
+  snmp_mib = {
+    sysname     = "MibResetTest"
+    syscontact  = "reset@example.com"
+    syslocation = "Reset Lab"
+  }
+}
+`
+
+func TestAccSnmpResourceDeleteResetsMib(t *testing.T) {
+	// Capture baseline MIB before test so we can restore after.
+	baseline, err := captureSnmpMibBaseline()
+	if err != nil {
+		t.Skipf("Cannot capture MIB baseline: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := restoreSnmpMibBaseline(baseline); err != nil {
+			t.Logf("WARNING: failed to restore MIB baseline: %v", err)
+		} else {
+			t.Logf("MIB baseline restored: sysName=%q sysContact=%q sysLocation=%q",
+				baseline.SysName, baseline.SysContact, baseline.SysLocation)
+		}
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		// CheckDestroy verifies MIB was reset to empty strings AND
+		// that test communities were removed.
+		CheckDestroy: func(s *terraform.State) error {
+			// First check: test communities cleaned up
+			if err := testAccCheckSnmpDestroy(s); err != nil {
+				return err
+			}
+			// Second check: MIB fields are empty strings
+			return testAccCheckSnmpMibResetOnDevice()(s)
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create with MIB values — verify they land on the device.
+			{
+				Config: testAccSnmpMibResetConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_snmp.mib_reset", "snmp_mib.sysname", "MibResetTest"),
+					resource.TestCheckResourceAttr("f5os_snmp.mib_reset", "snmp_mib.syscontact", "reset@example.com"),
+					resource.TestCheckResourceAttr("f5os_snmp.mib_reset", "snmp_mib.syslocation", "Reset Lab"),
+					testAccCheckSnmpMibOnDevice("MibResetTest", "reset@example.com", "Reset Lab"),
+					testAccCheckSnmpCommunityOnDevice("test_mib_reset_community", "v2c"),
+				),
+			},
+			// Destroy is automatic. CheckDestroy above verifies:
+			// 1. test_mib_reset_community is gone
+			// 2. sysName, sysContact, sysLocation are all ""
+			// t.Cleanup restores the original baseline MIB values.
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test HCL configs
+// ---------------------------------------------------------------------------
 
 const testAccSnmpResourceConfig = `
 resource "f5os_snmp" "test" {

--- a/internal/provider/f5os_snmp_unit_test.go
+++ b/internal/provider/f5os_snmp_unit_test.go
@@ -20,6 +20,8 @@ type mockSnmp struct {
 	delCommunities []string
 	delUsers       []string
 	failOn         string
+	snmpConfigResp []byte
+	snmpMibResp    []byte
 }
 
 func (m *mockSnmp) record(call string, payload []byte) error {
@@ -63,6 +65,24 @@ func (m *mockSnmp) DeleteSnmpUser(name string) error {
 		return errors.New("forced error: DeleteSnmpUser")
 	}
 	return nil
+}
+func (m *mockSnmp) GetSnmpConfig() ([]byte, error) {
+	if m.failOn == "GetSnmpConfig" {
+		return nil, errors.New("forced error: GetSnmpConfig")
+	}
+	if m.snmpConfigResp != nil {
+		return m.snmpConfigResp, nil
+	}
+	return []byte(`{"f5-system-snmp:snmp":{}}`), nil
+}
+func (m *mockSnmp) GetSnmpMib() ([]byte, error) {
+	if m.failOn == "GetSnmpMib" {
+		return nil, errors.New("forced error: GetSnmpMib")
+	}
+	if m.snmpMibResp != nil {
+		return m.snmpMibResp, nil
+	}
+	return []byte(`{"SNMPv2-MIB:system":{"sysName":"","sysContact":"","sysLocation":""}}`), nil
 }
 
 // --- Tests ---
@@ -253,7 +273,7 @@ func TestUpdateSnmpConfig_OrderAndCalls(t *testing.T) {
 	}
 }
 
-// 7) deleteSnmpConfig order & names
+// 7) deleteSnmpConfig order & names (with MIB reset)
 func TestDeleteSnmpConfig_OrderAndNames(t *testing.T) {
 	m := &mockSnmp{}
 	r := &SnmpResource{client: m}
@@ -263,14 +283,25 @@ func TestDeleteSnmpConfig_OrderAndNames(t *testing.T) {
 	communities := []SnmpCommunityModel{{Name: types.StringValue("c1")}}
 	users := []SnmpUserModel{{Name: types.StringValue("u1")}}
 
-	if err := r.deleteSnmpConfig(ctx, communities, targets, users); err != nil {
+	if err := r.deleteSnmpConfig(ctx, communities, targets, users, true); err != nil {
 		t.Fatalf("deleteSnmpConfig error: %v", err)
 	}
 
-	// Verify call order roughly: deletes recorded as methods called
-	wantPrefix := []string{"DeleteSnmpTarget", "DeleteSnmpTarget", "DeleteSnmpCommunity", "DeleteSnmpUser"}
-	if !reflect.DeepEqual(m.calls, wantPrefix) {
-		t.Fatalf("delete order mismatch\n got: %v\nwant: %v", m.calls, wantPrefix)
+	// Verify call order: targets first, then communities, then users, then MIB reset
+	wantCalls := []string{"DeleteSnmpTarget", "DeleteSnmpTarget", "DeleteSnmpCommunity", "DeleteSnmpUser", "UpdateSnmpMib"}
+	if !reflect.DeepEqual(m.calls, wantCalls) {
+		t.Fatalf("delete order mismatch\n got: %v\nwant: %v", m.calls, wantCalls)
+	}
+
+	// Verify the MIB reset payload contains empty strings
+	lastPayload := m.payloads[len(m.payloads)-1]
+	var mibReset map[string]map[string]string
+	if err := json.Unmarshal(lastPayload, &mibReset); err != nil {
+		t.Fatalf("failed to unmarshal MIB reset payload: %v", err)
+	}
+	sys := mibReset["SNMPv2-MIB:system"]
+	if sys["SNMPv2-MIB:sysName"] != "" || sys["SNMPv2-MIB:sysContact"] != "" || sys["SNMPv2-MIB:sysLocation"] != "" {
+		t.Fatalf("MIB reset should set all fields to empty strings, got: %v", sys)
 	}
 	if !reflect.DeepEqual(m.delTargets, []string{"t1", "t2"}) {
 		t.Fatalf("deleted targets mismatch: %v", m.delTargets)
@@ -283,19 +314,32 @@ func TestDeleteSnmpConfig_OrderAndNames(t *testing.T) {
 	}
 }
 
-// // 8) computeSnmpResourceID stable hashing
-// func TestComputeSnmpResourceID_Deterministic(t *testing.T) {
-// 	mib := &SnmpMibModel{SysName: types.StringValue("dev")}
-// 	aCom := []SnmpCommunityModel{{Name: types.StringValue("a")}, {Name: types.StringValue("b")}}
-// 	bCom := []SnmpCommunityModel{{Name: types.StringValue("b")}, {Name: types.StringValue("a")}}
-// 	aTar := []SnmpTargetModel{{Name: types.StringValue("t1")}, {Name: types.StringValue("t2")}}
-// 	bTar := []SnmpTargetModel{{Name: types.StringValue("t2")}, {Name: types.StringValue("t1")}}
-// 	aUsr := []SnmpUserModel{{Name: types.StringValue("u1")}, {Name: types.StringValue("u2")}}
-// 	bUsr := []SnmpUserModel{{Name: types.StringValue("u2")}, {Name: types.StringValue("u1")}}
+// 7b) deleteSnmpConfig skips MIB reset when resetMib is false
+func TestDeleteSnmpConfig_SkipsMibResetWhenNotManaged(t *testing.T) {
+	m := &mockSnmp{}
+	r := &SnmpResource{client: m}
+	ctx := context.Background()
 
-// 	id1 := computeSnmpResourceID(aCom, aTar, aUsr, mib)
-// 	id2 := computeSnmpResourceID(bCom, bTar, bUsr, mib)
-// 	if id1 != id2 {
-// 		t.Fatalf("hash should be deterministic; got %q vs %q", id1, id2)
-// 	}
-// }
+	targets := []SnmpTargetModel{{Name: types.StringValue("t1")}}
+	communities := []SnmpCommunityModel{{Name: types.StringValue("c1")}}
+	var users []SnmpUserModel
+
+	if err := r.deleteSnmpConfig(ctx, communities, targets, users, false); err != nil {
+		t.Fatalf("deleteSnmpConfig error: %v", err)
+	}
+
+	// MIB reset must NOT appear in the call list
+	wantCalls := []string{"DeleteSnmpTarget", "DeleteSnmpCommunity"}
+	if !reflect.DeepEqual(m.calls, wantCalls) {
+		t.Fatalf("call mismatch\n got: %v\nwant: %v", m.calls, wantCalls)
+	}
+
+	// No UpdateSnmpMib payload should have been recorded
+	for _, call := range m.calls {
+		if call == "UpdateSnmpMib" {
+			t.Fatal("UpdateSnmpMib should not be called when resetMib is false")
+		}
+	}
+}
+
+

--- a/internal/provider/f5os_system_resource.go
+++ b/internal/provider/f5os_system_resource.go
@@ -166,7 +166,7 @@ func (r *SystemResource) Create(ctx context.Context, req resource.CreateRequest,
 		tflog.Debug(ctx, fmt.Sprintf("[CREATE], Token Lifetime Resp:%+v", string(res)))
 	}
 
-	if (!data.CliTimeout.IsNull() && !data.CliTimeout.IsUnknown()) || (data.SshdIdleTimeout.IsNull() && data.SshdIdleTimeout.IsUnknown()) {
+	if (!data.CliTimeout.IsNull() && !data.CliTimeout.IsUnknown()) || (!data.SshdIdleTimeout.IsNull() && !data.SshdIdleTimeout.IsUnknown()) {
 		systemSettingsReq := getSystemSettingsConfig(ctx, data)
 
 		byteBody, err := json.Marshal(systemSettingsReq)
@@ -404,7 +404,10 @@ func (r *SystemResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	r.SystemResourceModelToState(ctx, resSystemConfig, resClockConfig, resHttpdBlock, resSshdBlock, resSystemSettingsConfig, resTokenLifetime, data)
+	// Hostname is null only during import (ImportState sets id alone).
+	isImport := data.Hostname.IsNull()
+
+	r.SystemResourceModelToState(ctx, resSystemConfig, resClockConfig, resHttpdBlock, resSshdBlock, resSystemSettingsConfig, resTokenLifetime, data, isImport)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -440,7 +443,7 @@ func (r *SystemResource) Update(ctx context.Context, req resource.UpdateRequest,
 		tflog.Debug(ctx, fmt.Sprintf("[UPDATE], Token Lifetime Resp:%+v", string(res)))
 	}
 
-	if (!data.CliTimeout.IsNull() && !data.CliTimeout.IsUnknown()) || (data.SshdIdleTimeout.IsNull() && data.SshdIdleTimeout.IsUnknown()) {
+	if (!data.CliTimeout.IsNull() && !data.CliTimeout.IsUnknown()) || (!data.SshdIdleTimeout.IsNull() && !data.SshdIdleTimeout.IsUnknown()) {
 		systemSettingsReq := getSystemSettingsConfig(ctx, data)
 
 		byteBody, err := json.Marshal(systemSettingsReq)
@@ -586,6 +589,9 @@ func (r *SystemResource) Update(ctx context.Context, req resource.UpdateRequest,
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// Delete only guards optional fields with IsNull() (not IsUnknown()) because
+// state values in Delete are never Unknown — Unknown only appears during planning.
+// Create/Update use both IsNull() && IsUnknown() checks since plan values can be Unknown.
 func (r *SystemResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data *SystemResourceModel
 
@@ -605,17 +611,25 @@ func (r *SystemResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	baseURL = "/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/config/lifetime/lifetime"
-	err := r.client.DeleteRequest(baseURL)
-	if err != nil {
-		resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Token Lifetime, got error: %s", err))
-		return
+	if !data.TokenLifetime.IsNull() {
+		baseURL = "/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/config/lifetime/lifetime"
+		err := r.client.DeleteRequest(baseURL)
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Token Lifetime, got error: %s", err))
+			return
+		}
 	}
 
 	baseURL = "/openconfig-system:system/f5-system-settings:settings"
-	paths = []string{"idle-timeout", "sshd-idle-timeout"}
-	for _, path := range paths {
-		err := r.client.DeleteRequest(fmt.Sprintf(`%s/%s`, baseURL, path))
+	if !data.CliTimeout.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s/%s`, baseURL, "idle-timeout"))
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting System Settings, got error: %s", err))
+			return
+		}
+	}
+	if !data.SshdIdleTimeout.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s/%s`, baseURL, "sshd-idle-timeout"))
 		if err != nil {
 			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting System Settings, got error: %s", err))
 			return
@@ -623,22 +637,39 @@ func (r *SystemResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	baseURL = "/openconfig-system:system/f5-security-ciphers:security/services/service"
-	paths = []string{"ssl-cipher-suite", "ciphers", "kexalgorithms", "macs", "host-key-algorithms"}
-	// services := []string{"httpd", "sshd"}
-
-	for _, path := range paths {
-		if path == "ssl-cipher-suite" {
-			err := r.client.DeleteRequest(fmt.Sprintf(`%s="httpd"/config/%s`, baseURL, path))
-			if err != nil {
-				resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting System Settings, got error: %s", err))
-				return
-			}
-		} else {
-			err := r.client.DeleteRequest(fmt.Sprintf(`%s="sshd"/config/%s`, baseURL, path))
-			if err != nil {
-				resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Ciphers Config, got error: %s", err))
-				return
-			}
+	if !data.HttpdCipherSuite.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s="httpd"/config/%s`, baseURL, "ssl-cipher-suite"))
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting System Settings, got error: %s", err))
+			return
+		}
+	}
+	if !data.SshdCiphers.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s="sshd"/config/%s`, baseURL, "ciphers"))
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Ciphers Config, got error: %s", err))
+			return
+		}
+	}
+	if !data.SshdKeyAlg.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s="sshd"/config/%s`, baseURL, "kexalgorithms"))
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Ciphers Config, got error: %s", err))
+			return
+		}
+	}
+	if !data.SshdMacAlg.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s="sshd"/config/%s`, baseURL, "macs"))
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Ciphers Config, got error: %s", err))
+			return
+		}
+	}
+	if !data.SshdHkeyAlg.IsNull() {
+		err := r.client.DeleteRequest(fmt.Sprintf(`%s="sshd"/config/%s`, baseURL, "host-key-algorithms"))
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Error:", fmt.Sprintf("Failure while Deleting Ciphers Config, got error: %s", err))
+			return
 		}
 	}
 
@@ -651,7 +682,7 @@ func (r *SystemResource) ImportState(ctx context.Context, req resource.ImportSta
 
 func (r *SystemResource) SystemResourceModelToState(ctx context.Context, resSystemConfig *f5ossdk.F5ResSystemConfig, resClockConfig *f5ossdk.F5ResClockConfig,
 	resHttpdBlock *f5ossdk.HttpdBlock, resSshdBlock *f5ossdk.SshdBlock, resSystemSettingsConfig *f5ossdk.F5ResSettingsConfig,
-	resTokenLifetime *f5ossdk.F5ResTokenLifetime, data *SystemResourceModel) {
+	resTokenLifetime *f5ossdk.F5ResTokenLifetime, data *SystemResourceModel, isImport bool) {
 
 	data.Hostname = types.StringValue(resSystemConfig.OpenConfigSystem.Hostname)
 
@@ -660,28 +691,46 @@ func (r *SystemResource) SystemResourceModelToState(ctx context.Context, resSyst
 
 	data.Timezone = types.StringValue(resClockConfig.OpenConfigClock.Config.TimeZoneName)
 
-	data.HttpdCipherSuite = types.StringValue(resHttpdBlock.Config.SSLCipherSuite)
-
-	data.SshdCiphers.ElementsAs(ctx, &resSshdBlock.Config.Ciphers, false)
-	data.SshdMacAlg.ElementsAs(ctx, &resSshdBlock.Config.MACs, false)
-	data.SshdKeyAlg.ElementsAs(ctx, &resSshdBlock.Config.KexAlgorithms, false)
-	data.SshdHkeyAlg.ElementsAs(ctx, &resSshdBlock.Config.HostKeyAlgos, false)
-
-	switch v := resSystemSettingsConfig.Settings.Config.CliTimeout.(type) {
-	case string:
-		id, _ := strconv.Atoi(v)
-		data.CliTimeout = types.Int64Value(int64(id))
-	case int:
-		id := int(v)
-		data.CliTimeout = types.Int64Value(int64(id))
-	default:
-		// Use id
+	if !data.HttpdCipherSuite.IsNull() || isImport {
+		data.HttpdCipherSuite = types.StringValue(resHttpdBlock.Config.SSLCipherSuite)
 	}
 
-	// data.CliTimeout = types.Int64Value(int64(resSystemSettingsConfig.Settings.Config.CliTimeout.(int)))
-	data.SshdIdleTimeout = types.StringValue(resSystemSettingsConfig.Settings.Config.SshdIdleTimeout.(string))
+	if !data.SshdCiphers.IsNull() || isImport {
+		data.SshdCiphers, _ = types.ListValueFrom(ctx, types.StringType, resSshdBlock.Config.Ciphers)
+	}
+	if !data.SshdMacAlg.IsNull() || isImport {
+		data.SshdMacAlg, _ = types.ListValueFrom(ctx, types.StringType, resSshdBlock.Config.MACs)
+	}
+	if !data.SshdKeyAlg.IsNull() || isImport {
+		data.SshdKeyAlg, _ = types.ListValueFrom(ctx, types.StringType, resSshdBlock.Config.KexAlgorithms)
+	}
+	if !data.SshdHkeyAlg.IsNull() || isImport {
+		data.SshdHkeyAlg, _ = types.ListValueFrom(ctx, types.StringType, resSshdBlock.Config.HostKeyAlgos)
+	}
 
-	data.TokenLifetime = types.Int64Value(int64(resTokenLifetime.Lifetime))
+	if !data.CliTimeout.IsNull() || isImport {
+		switch v := resSystemSettingsConfig.Settings.Config.CliTimeout.(type) {
+		case string:
+			id, _ := strconv.Atoi(v)
+			data.CliTimeout = types.Int64Value(int64(id))
+		case int:
+			data.CliTimeout = types.Int64Value(int64(v))
+		case float64:
+			data.CliTimeout = types.Int64Value(int64(v))
+		default:
+			// Unrecognized type; leave CliTimeout unchanged
+		}
+	}
+
+	if !data.SshdIdleTimeout.IsNull() || isImport {
+		if s, ok := resSystemSettingsConfig.Settings.Config.SshdIdleTimeout.(string); ok {
+			data.SshdIdleTimeout = types.StringValue(s)
+		}
+	}
+
+	if !data.TokenLifetime.IsNull() || isImport {
+		data.TokenLifetime = types.Int64Value(int64(resTokenLifetime.Lifetime))
+	}
 
 }
 

--- a/internal/provider/f5os_system_resource_test.go
+++ b/internal/provider/f5os_system_resource_test.go
@@ -1,10 +1,187 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
+
+// ---------------------------------------------------------------------------
+// Unit test: verifies Read populates sshd_ciphers, sshd_kex_alg, sshd_mac_alg,
+// sshd_hkey_alg from the device API response (not from stale state).
+// ---------------------------------------------------------------------------
+
+const testUnitSystemCreateConfig = `
+resource "f5os_system" "test" {
+  hostname          = "unit-test-host"
+  motd              = "unit test motd"
+  login_banner      = "unit test banner"
+  timezone          = "UTC"
+  cli_timeout       = 3600
+  token_lifetime    = 15
+  sshd_idle_timeout = "1800"
+  httpd_ciphersuite = "ECDHE-RSA-AES256-GCM-SHA384"
+  sshd_ciphers      = ["aes256-ctr", "aes256-gcm@openssh.com"]
+  sshd_kex_alg      = ["ecdh-sha2-nistp384"]
+  sshd_mac_alg      = ["hmac-sha2-256"]
+  sshd_hkey_alg     = ["ssh-ed25519"]
+}
+`
+
+func TestUnitSystemReadPopulatesSSHLists(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	// Mock: PATCH /openconfig-system:system (Create/Update system config)
+	mux.HandleFunc("/restconf/data/openconfig-system:system", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Mock: PATCH /openconfig-system:system/aaa (token lifetime)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Mock: PATCH /openconfig-system:system/f5-system-settings:settings
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-settings:settings", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PATCH":
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"f5-system-settings:settings": {
+					"config": {
+						"idle-timeout": "3600",
+						"sshd-idle-timeout": "1800"
+					}
+				}
+			}`))
+		}
+	})
+
+	// Mock: GET /openconfig-system:system/config (Read hostname/motd/login-banner)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"openconfig-system:config": {
+				"hostname": "unit-test-host",
+				"motd-banner": "unit test motd",
+				"login-banner": "unit test banner"
+			}
+		}`))
+	})
+
+	// Mock: GET /openconfig-system:system/clock (Read timezone)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/clock", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"openconfig-system:clock": {
+				"config": {
+					"timezone-name": "UTC"
+				}
+			}
+		}`))
+	})
+
+	// Mock: GET /openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/state/lifetime
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/state/lifetime", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-aaa-confd-restconf-token:lifetime": 15}`))
+	})
+
+	// Mock: cipher services — returns BOTH httpd and sshd blocks.
+	// The sshd block values are what Read should populate into state.
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"f5-security-ciphers:service": [
+				{
+					"name": "httpd",
+					"config": {
+						"name": "httpd",
+						"ssl-ciphersuite": "ECDHE-RSA-AES256-GCM-SHA384"
+					}
+				},
+				{
+					"name": "sshd",
+					"config": {
+						"name": "sshd",
+						"ciphers": ["aes256-ctr", "aes256-gcm@openssh.com"],
+						"kexalgorithms": ["ecdh-sha2-nistp384"],
+						"macs": ["hmac-sha2-256"],
+						"host-key-algorithms": ["ssh-ed25519"]
+					}
+				}
+			]
+		}`))
+	})
+
+	// Mock: PUT endpoints for cipher/SSH config (Create writes)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=httpd/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/ciphers", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/kexalgorithms", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/macs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/host-key-algorithms", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitSystemCreateConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Scalar attributes — confirm Read populated them
+					resource.TestCheckResourceAttr("f5os_system.test", "hostname", "unit-test-host"),
+					resource.TestCheckResourceAttr("f5os_system.test", "motd", "unit test motd"),
+					resource.TestCheckResourceAttr("f5os_system.test", "login_banner", "unit test banner"),
+					resource.TestCheckResourceAttr("f5os_system.test", "timezone", "UTC"),
+					resource.TestCheckResourceAttr("f5os_system.test", "cli_timeout", "3600"),
+					resource.TestCheckResourceAttr("f5os_system.test", "token_lifetime", "15"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_idle_timeout", "1800"),
+					resource.TestCheckResourceAttr("f5os_system.test", "httpd_ciphersuite", "ECDHE-RSA-AES256-GCM-SHA384"),
+
+					// SSH list attributes — the fix under test.
+					// These must be populated FROM the mock API response,
+					// not preserved from old state. Before the fix,
+					// ElementsAs was used backwards and these would be
+					// empty/stale after Read.
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_ciphers.#", "2"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_ciphers.0", "aes256-ctr"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_ciphers.1", "aes256-gcm@openssh.com"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_kex_alg.#", "1"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_kex_alg.0", "ecdh-sha2-nistp384"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_mac_alg.#", "1"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_mac_alg.0", "hmac-sha2-256"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_hkey_alg.#", "1"),
+					resource.TestCheckResourceAttr("f5os_system.test", "sshd_hkey_alg.0", "ssh-ed25519"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests (real device)
+// ---------------------------------------------------------------------------
 
 func TestAccSystemCreateTC1Resource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -203,4 +380,584 @@ resource "f5os_system" "system_settings" {
   sshd_kex_alg = ["ecdh-sha2-nistp384", "ecdh-sha2-nistp521"]
   sshd_mac_alg = ["hmac-sha1-96"]
   sshd_hkey_alg = ["ssh-rsa"]
+}`
+
+// ---------------------------------------------------------------------------
+// Acceptance test helpers
+// ---------------------------------------------------------------------------
+
+// newSystemClientFromEnv creates a fresh f5osclient session from environment
+// variables. Port defaults to 8888 to match the provider.
+func newSystemClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
+
+// testAccCheckSystemSSHListsOnDevice queries the device cipher service
+// endpoints directly and verifies the sshd ciphers, kex, macs, and hkey
+// lists match the expected values.
+func testAccCheckSystemSSHListsOnDevice(
+	expectedCiphers []string,
+	expectedKex []string,
+	expectedMacs []string,
+	expectedHkey []string,
+) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSystemClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		data, err := client.GetRequest("/openconfig-system:system/f5-security-ciphers:security/services/service")
+		if err != nil {
+			return fmt.Errorf("failed to read cipher services: %w", err)
+		}
+
+		var raw map[string][]map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("failed to parse cipher services: %w", err)
+		}
+
+		for _, svc := range raw["f5-security-ciphers:service"] {
+			if svc["name"] != "sshd" {
+				continue
+			}
+			cfg, ok := svc["config"].(map[string]any)
+			if !ok {
+				return fmt.Errorf("sshd config is not a map")
+			}
+
+			if err := compareStringList(cfg, "ciphers", expectedCiphers); err != nil {
+				return err
+			}
+			if err := compareStringList(cfg, "kexalgorithms", expectedKex); err != nil {
+				return err
+			}
+			if err := compareStringList(cfg, "macs", expectedMacs); err != nil {
+				return err
+			}
+			if err := compareStringList(cfg, "host-key-algorithms", expectedHkey); err != nil {
+				return err
+			}
+			return nil
+		}
+		return fmt.Errorf("sshd service not found on device")
+	}
+}
+
+// compareStringList compares a JSON array field against expected string values.
+func compareStringList(cfg map[string]any, key string, expected []string) error {
+	raw, ok := cfg[key]
+	if !ok || raw == nil {
+		if len(expected) == 0 {
+			return nil
+		}
+		return fmt.Errorf("device %s: expected %v, got (absent)", key, expected)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return fmt.Errorf("device %s: expected array, got %T", key, raw)
+	}
+	if len(arr) != len(expected) {
+		return fmt.Errorf("device %s: expected %d entries, got %d", key, len(expected), len(arr))
+	}
+	for i, v := range arr {
+		s, _ := v.(string)
+		if s != expected[i] {
+			return fmt.Errorf("device %s[%d]: expected %q, got %q", key, i, expected[i], s)
+		}
+	}
+	return nil
+}
+
+// testAccCheckSystemHostnameOnDevice verifies the hostname on the device.
+func testAccCheckSystemHostnameOnDevice(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newSystemClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		data, err := client.GetRequest("/openconfig-system:system/config")
+		if err != nil {
+			return fmt.Errorf("failed to read system config: %w", err)
+		}
+		var resp f5ossdk.F5ResSystemConfig
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return fmt.Errorf("failed to parse system config: %w", err)
+		}
+		if resp.OpenConfigSystem.Hostname != expected {
+			return fmt.Errorf("hostname: expected %q, got %q", expected, resp.OpenConfigSystem.Hostname)
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test: verifies Read populates SSH lists from the device after
+// Create, using direct API verification alongside Terraform state checks.
+// ---------------------------------------------------------------------------
+
+// Uses a safe cipher configuration that preserves device connectivity:
+// - sshd_ciphers includes aes256-ctr + aes256-gcm (broadly supported)
+// - sshd_kex_alg includes ecdh-sha2-nistp256 + nistp384 (broadly supported)
+// - sshd_hkey_alg includes all 4 baseline algorithms (no reduction)
+// - sshd_mac_alg includes hmac-sha1-96 (matches baseline)
+const testAccSystemReadSSHListsConfig = `
+resource "f5os_system" "read_test" {
+  hostname          = "r5900-read-test"
+  motd              = "Read SSH lists test"
+  login_banner      = "Read test banner"
+  timezone          = "UTC"
+  cli_timeout       = 3500
+  token_lifetime    = 16
+  sshd_idle_timeout = "1800"
+  httpd_ciphersuite = "ECDHE-RSA-AES256-GCM-SHA384"
+  sshd_ciphers      = ["aes256-ctr", "aes256-gcm@openssh.com"]
+  sshd_kex_alg      = ["ecdh-sha2-nistp256", "ecdh-sha2-nistp384"]
+  sshd_mac_alg      = ["hmac-sha1-96"]
+  sshd_hkey_alg     = ["ecdsa-sha2-nistp256", "rsa-sha2-256", "rsa-sha2-512", "ssh-ed25519"]
+}
+`
+
+func TestAccSystemReadPopulatesSSHLists(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemReadSSHListsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// --- Terraform state assertions ---
+					resource.TestCheckResourceAttr("f5os_system.read_test", "hostname", "r5900-read-test"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "motd", "Read SSH lists test"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "login_banner", "Read test banner"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "timezone", "UTC"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "cli_timeout", "3500"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "token_lifetime", "16"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_idle_timeout", "1800"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "httpd_ciphersuite", "ECDHE-RSA-AES256-GCM-SHA384"),
+
+					// SSH lists — the fix under test. Before the fix
+					// these would be stale because ElementsAs was used
+					// backwards. After the fix, Read populates them from
+					// the device via types.ListValueFrom.
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_ciphers.#", "2"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_ciphers.0", "aes256-ctr"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_ciphers.1", "aes256-gcm@openssh.com"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_kex_alg.#", "2"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_kex_alg.0", "ecdh-sha2-nistp256"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_kex_alg.1", "ecdh-sha2-nistp384"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_mac_alg.#", "1"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_mac_alg.0", "hmac-sha1-96"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_hkey_alg.#", "4"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_hkey_alg.0", "ecdsa-sha2-nistp256"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_hkey_alg.1", "rsa-sha2-256"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_hkey_alg.2", "rsa-sha2-512"),
+					resource.TestCheckResourceAttr("f5os_system.read_test", "sshd_hkey_alg.3", "ssh-ed25519"),
+
+					// --- Direct device API assertions ---
+					testAccCheckSystemHostnameOnDevice("r5900-read-test"),
+					testAccCheckSystemSSHListsOnDevice(
+						[]string{"aes256-ctr", "aes256-gcm@openssh.com"},
+						[]string{"ecdh-sha2-nistp256", "ecdh-sha2-nistp384"},
+						[]string{"hmac-sha1-96"},
+						[]string{"ecdsa-sha2-nistp256", "rsa-sha2-256", "rsa-sha2-512", "ssh-ed25519"},
+					),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unit test: verifies no panic when SshdIdleTimeout is nil (never configured)
+// ---------------------------------------------------------------------------
+
+func TestUnitSystemCreateNoSshdIdleTimeoutTC3Resource(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/yang-data+json")
+			w.Header().Set("X-Auth-Token", "eyJhbGciOiJIXzI2NiIsInR6cCI6IkcXVCJ9.eyJhdXRoaW5mbyI6ImFkbWluIDEwMDAgOTAwMCBcL3ZhclwvRjVcL3BhcnRpdGlvbiIsImV4cCI6MTY4MDcyMDc4MiwiaWF0IjoxNjgwNzE5ODgyLCJyZW5ld2xpbWl0IjoiNSIsInVzZXJpbmZvIjoiYWRtaW4gMTcyLjE4LjIzMy4yMiJ9.c6Fw4AVm9dN4F-rRJZ1655Ks3xEWCzdAvum-Q3K7cwU")
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-settings:settings", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"f5-system-settings:settings":{"config":{}}}`))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:config":{"hostname":"system-no-sshd.example.net","login-banner":"Welcome.","motd-banner":"Hello"}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/clock", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:clock":{"config":{"timezone-name":"UTC"}}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-security-ciphers:service":[{"name":"httpd","config":{}},{"name":"sshd","config":{}}]}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/state/lifetime", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-aaa-confd-restconf-token:lifetime": 15}`))
+	})
+
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemCreateNoSshdIdleTimeoutConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "id", "system-no-sshd.example.net"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "hostname", "system-no-sshd.example.net"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "sshd_idle_timeout"),
+				),
+			},
+		},
+	})
+}
+
+const testAccSystemCreateNoSshdIdleTimeoutConfig = `
+resource "f5os_system" "system_settings" {
+  hostname = "system-no-sshd.example.net"
+  motd = "Hello"
+  login_banner = "Welcome."
+  timezone = "UTC"
+}`
+
+// ---------------------------------------------------------------------------
+// Unit test: verifies SshdIdleTimeout triggers a settings PATCH when configured
+// ---------------------------------------------------------------------------
+
+func TestUnitSystemSshdIdleTimeoutTriggersPatch(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var settingsPatchCalled bool
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/yang-data+json")
+			w.Header().Set("X-Auth-Token", "eyJhbGciOiJIXzI2NiIsInR6cCI6IkcXVCJ9.eyJhdXRoaW5mbyI6ImFkbWluIDEwMDAgOTAwMCBcL3ZhclwvRjVcL3BhcnRpdGlvbiIsImV4cCI6MTY4MDcyMDc4MiwiaWF0IjoxNjgwNzE5ODgyLCJyZW5ld2xpbWl0IjoiNSIsInVzZXJpbmZvIjoiYWRtaW4gMTcyLjE4LjIzMy4yMiJ9.c6Fw4AVm9dN4F-rRJZ1655Ks3xEWCzdAvum-Q3K7cwU")
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-settings:settings", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			settingsPatchCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"f5-system-settings:settings":{"config":{"sshd-idle-timeout":"1800"}}}`))
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:config":{"hostname":"sshd-patch-test.example.net","login-banner":"Welcome.","motd-banner":"Hello"}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/clock", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:clock":{"config":{"timezone-name":"UTC"}}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-security-ciphers:service":[{"name":"httpd","config":{}},{"name":"sshd","config":{}}]}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/state/lifetime", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-aaa-confd-restconf-token:lifetime": 15}`))
+	})
+
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemSshdIdleTimeoutConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "id", "sshd-patch-test.example.net"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "sshd_idle_timeout", "1800"),
+					func(s *terraform.State) error {
+						if !settingsPatchCalled {
+							return fmt.Errorf("expected PATCH to /f5-system-settings:settings but it was not called")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+const testAccSystemSshdIdleTimeoutConfig = `
+resource "f5os_system" "system_settings" {
+  hostname          = "sshd-patch-test.example.net"
+  motd              = "Hello"
+  login_banner      = "Welcome."
+  timezone          = "UTC"
+  sshd_idle_timeout = 1800
+}`
+
+// ---------------------------------------------------------------------------
+// Unit test: import populates all optional fields from device
+// ---------------------------------------------------------------------------
+
+func TestUnitSystemImportPopulatesOptionalFields(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/yang-data+json")
+			w.Header().Set("X-Auth-Token", "eyJhbGciOiJIXzI2NiIsInR6cCI6IkcXVCJ9.eyJhdXRoaW5mbyI6ImFkbWluIDEwMDAgOTAwMCBcL3ZhclwvRjVcL3BhcnRpdGlvbiIsImV4cCI6MTY4MDcyMDc4MiwiaWF0IjoxNjgwNzE5ODgyLCJyZW5ld2xpbWl0IjoiNSIsInVzZXJpbmZvIjoiYWRtaW4gMTcyLjE4LjIzMy4yMiJ9.c6Fw4AVm9dN4F-rRJZ1655Ks3xEWCzdAvum-Q3K7cwU")
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-settings:settings", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"f5-system-settings:settings":{"config":{"idle-timeout":3600,"sshd-idle-timeout":"1800"}}}`))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:config":{"hostname":"import-test.example.net","login-banner":"Imported banner","motd-banner":"Imported motd"}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/clock", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:clock":{"config":{"timezone-name":"America/Los_Angeles"}}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-security-ciphers:service":[{"name":"httpd","config":{"ssl-ciphersuite":"ECDHE-RSA-AES256-GCM-SHA384"}},{"name":"sshd","config":{"ciphers":["aes256-ctr"],"kexalgorithms":["ecdh-sha2-nistp384"],"macs":["hmac-sha2-256"],"host-key-algorithms":["ssh-ed25519"]}}]}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=httpd/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/ciphers", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/kexalgorithms", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/macs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service=sshd/config/host-key-algorithms", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/state/lifetime", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-aaa-confd-restconf-token:lifetime": 20}`))
+	})
+
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the resource so it exists in state
+			{
+				Config: testAccSystemImportConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "hostname", "import-test.example.net"),
+				),
+			},
+			// Step 2: Import and verify all optional fields are populated
+			{
+				ResourceName:      "f5os_system.system_settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "import-test.example.net",
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Required fields
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "hostname", "import-test.example.net"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "motd", "Imported motd"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "login_banner", "Imported banner"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "timezone", "America/Los_Angeles"),
+					// Optional fields — must be populated from device during import
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "cli_timeout", "3600"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "token_lifetime", "20"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "sshd_idle_timeout", "1800"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "httpd_ciphersuite", "ECDHE-RSA-AES256-GCM-SHA384"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "sshd_ciphers.0", "aes256-ctr"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "sshd_kex_alg.0", "ecdh-sha2-nistp384"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "sshd_mac_alg.0", "hmac-sha2-256"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "sshd_hkey_alg.0", "ssh-ed25519"),
+				),
+			},
+		},
+	})
+}
+
+const testAccSystemImportConfig = `
+resource "f5os_system" "system_settings" {
+  hostname          = "import-test.example.net"
+  motd              = "Imported motd"
+  login_banner      = "Imported banner"
+  timezone          = "America/Los_Angeles"
+  cli_timeout       = 3600
+  token_lifetime    = 20
+  sshd_idle_timeout = 1800
+  httpd_ciphersuite = "ECDHE-RSA-AES256-GCM-SHA384"
+  sshd_ciphers      = ["aes256-ctr"]
+  sshd_kex_alg      = ["ecdh-sha2-nistp384"]
+  sshd_mac_alg      = ["hmac-sha2-256"]
+  sshd_hkey_alg     = ["ssh-ed25519"]
+}`
+
+// ---------------------------------------------------------------------------
+// Unit test: minimal config with no optional fields — verifies no errors
+// during Create, Read, and Delete when optional attributes are omitted.
+// ---------------------------------------------------------------------------
+
+func TestUnitSystemMinimalConfigNoOptionalFields(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/yang-data+json")
+			w.Header().Set("X-Auth-Token", "eyJhbGciOiJIXzI2NiIsInR6cCI6IkcXVCJ9.eyJhdXRoaW5mbyI6ImFkbWluIDEwMDAgOTAwMCBcL3ZhclwvRjVcL3BhcnRpdGlvbiIsImV4cCI6MTY4MDcyMDc4MiwiaWF0IjoxNjgwNzE5ODgyLCJyZW5ld2xpbWl0IjoiNSIsInVzZXJpbmZvIjoiYWRtaW4gMTcyLjE4LjIzMy4yMiJ9.c6Fw4AVm9dN4F-rRJZ1655Ks3xEWCzdAvum-Q3K7cwU")
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-system-settings:settings", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"f5-system-settings:settings":{"config":{}}}`))
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/config", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:config":{"hostname":"minimal-test.example.net","login-banner":"Welcome.","motd-banner":"Hello"}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/clock", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"openconfig-system:clock":{"config":{"timezone-name":"UTC"}}}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/f5-security-ciphers:security/services/service", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-security-ciphers:service":[{"name":"httpd","config":{}},{"name":"sshd","config":{}}]}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-aaa-confd-restconf-token:restconf-token/state/lifetime", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"f5-aaa-confd-restconf-token:lifetime": 15}`))
+	})
+
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemMinimalConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "id", "minimal-test.example.net"),
+					resource.TestCheckResourceAttr("f5os_system.system_settings", "hostname", "minimal-test.example.net"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "cli_timeout"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "token_lifetime"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "sshd_idle_timeout"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "httpd_ciphersuite"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "sshd_ciphers"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "sshd_kex_alg"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "sshd_mac_alg"),
+					resource.TestCheckNoResourceAttr("f5os_system.system_settings", "sshd_hkey_alg"),
+				),
+			},
+		},
+	})
+}
+
+const testAccSystemMinimalConfig = `
+resource "f5os_system" "system_settings" {
+  hostname     = "minimal-test.example.net"
+  motd         = "Hello"
+  login_banner = "Welcome."
+  timezone     = "UTC"
 }`

--- a/internal/provider/f5os_tls_cert_key_resource.go
+++ b/internal/provider/f5os_tls_cert_key_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
-	"golang.org/x/mod/semver"
 )
 
 var _ resource.Resource = &PartitionCertKeyResource{}
@@ -147,8 +146,7 @@ func (r *PartitionCertKeyResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	version := "v" + r.client.PlatformVersion
-	if semver.Compare(semver.MajorMinor(version), "v1.8") >= 0 {
+	if platformVersionAtLeast(r.client.PlatformVersion, "v1.8") {
 		if data.SubjectAlternativeName.IsNull() || data.SubjectAlternativeName.IsUnknown() {
 			resp.Diagnostics.AddError("subject_alternative_name is required for platform version v1.8 and above", "")
 			return
@@ -192,9 +190,7 @@ func (r *PartitionCertKeyResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	version := r.client.PlatformVersion
-
-	if semver.Compare(semver.MajorMinor(version), "v1.8") >= 0 {
+	if platformVersionAtLeast(r.client.PlatformVersion, "v1.8") {
 		if data.SubjectAlternativeName.IsNull() || data.SubjectAlternativeName.IsUnknown() {
 			resp.Diagnostics.AddError("subject_alternative_name is required for platform version v1.8 and above", "")
 			return

--- a/internal/provider/f5os_user_resource.go
+++ b/internal/provider/f5os_user_resource.go
@@ -94,10 +94,13 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	username := plan.Username.ValueString()
 
 	// Try to create the user with all fields including secondary role
-	err := r.createUserWithRetry(ctx, plan)
+	createWarnings, err := r.createUserWithRetry(ctx, plan)
 	if err != nil {
 		resp.Diagnostics.AddError("User Create Error", err.Error())
 		return
+	}
+	for _, w := range createWarnings {
+		resp.Diagnostics.AddWarning("Role Assignment Warning", w)
 	}
 
 	// Set the password using the set-password endpoint
@@ -250,10 +253,13 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Step 1: Update user attributes (without password)
-	err = r.updateUserWithRetry(ctx, username, plan)
+	updateWarnings, err := r.updateUserWithRetry(ctx, username, plan)
 	if err != nil {
 		resp.Diagnostics.AddError("User Update Error", err.Error())
 		return
+	}
+	for _, w := range updateWarnings {
+		resp.Diagnostics.AddWarning("Role Update Warning", w)
 	}
 
 	// Step 2: Update password if it changed
@@ -695,15 +701,17 @@ func (r *UserResource) createUser(payload []byte) error {
 	return nil
 }
 
-// createUserWithRetry creates a user and assigns secondary role via separate endpoint
-func (r *UserResource) createUserWithRetry(ctx context.Context, plan UserModel) error {
+// createUserWithRetry creates a user and assigns secondary role via separate endpoint.
+// It returns a slice of warning messages for non-fatal issues (e.g. role assignment
+// failures) so the caller can surface them via resp.Diagnostics.AddWarning.
+func (r *UserResource) createUserWithRetry(ctx context.Context, plan UserModel) (warnings []string, err error) {
 	username := plan.Username.ValueString()
 	primaryRole := plan.Role.ValueString()
 
 	// Step 1: Create the user with primary role (never include secondary role in user config)
 	payload, err := r.createUserPayload(plan, false, false)
 	if err != nil {
-		return fmt.Errorf("failed to create payload: %w", err)
+		return nil, fmt.Errorf("failed to create payload: %w", err)
 	}
 
 	tflog.Info(ctx, "Creating F5OS user with primary role", map[string]interface{}{
@@ -714,7 +722,7 @@ func (r *UserResource) createUserWithRetry(ctx context.Context, plan UserModel) 
 
 	err = r.createUser(payload)
 	if err != nil {
-		return fmt.Errorf("failed to create user: %w", err)
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	// Step 2: Assign user to primary role via roles endpoint (this ensures they appear in role membership)
@@ -725,12 +733,10 @@ func (r *UserResource) createUserWithRetry(ctx context.Context, plan UserModel) 
 
 	err = r.assignUserToRole(ctx, username, primaryRole)
 	if err != nil {
-		tflog.Warn(ctx, "Failed to assign user to primary role, user created but role assignment may be incomplete",
-			map[string]interface{}{
-				"username":     username,
-				"primary_role": primaryRole,
-				"error":        err.Error(),
-			})
+		msg := fmt.Sprintf("User %q created but primary role %q assignment via roles endpoint failed: %s. "+
+			"The device may not reflect the intended role membership.", username, primaryRole, err.Error())
+		tflog.Warn(ctx, msg)
+		warnings = append(warnings, msg)
 	}
 
 	// Step 3: Assign secondary role if specified (using roles endpoint)
@@ -744,27 +750,26 @@ func (r *UserResource) createUserWithRetry(ctx context.Context, plan UserModel) 
 
 		err = r.assignUserToRole(ctx, username, secondaryRole)
 		if err != nil {
-			// If secondary role assignment fails, warn but don't fail the creation
-			tflog.Warn(ctx, "Failed to assign secondary role, user created with primary role only",
-				map[string]interface{}{
-					"username":       username,
-					"secondary_role": secondaryRole,
-					"error":          err.Error(),
-				})
+			msg := fmt.Sprintf("User %q created with primary role only; secondary role %q assignment failed: %s. "+
+				"The device may not reflect the intended role membership.", username, secondaryRole, err.Error())
+			tflog.Warn(ctx, msg)
+			warnings = append(warnings, msg)
 		}
 	}
 
-	return nil
+	return warnings, nil
 }
 
-// updateUserWithRetry updates a user and manages secondary role via separate endpoint
-func (r *UserResource) updateUserWithRetry(ctx context.Context, username string, plan UserModel) error {
+// updateUserWithRetry updates a user and manages secondary role via separate endpoint.
+// It returns a slice of warning messages for non-fatal issues (e.g. stale role removal
+// failures) so the caller can surface them via resp.Diagnostics.AddWarning.
+func (r *UserResource) updateUserWithRetry(ctx context.Context, username string, plan UserModel) (warnings []string, err error) {
 	primaryRole := plan.Role.ValueString()
 
 	// Step 1: Update user attributes with primary role (never include secondary role in user config)
 	payload, err := r.createUserPayload(plan, false, false)
 	if err != nil {
-		return fmt.Errorf("failed to create payload: %w", err)
+		return nil, fmt.Errorf("failed to create payload: %w", err)
 	}
 
 	tflog.Info(ctx, "Updating F5OS user with primary role", map[string]interface{}{
@@ -774,10 +779,47 @@ func (r *UserResource) updateUserWithRetry(ctx context.Context, username string,
 
 	err = r.updateUser(username, payload)
 	if err != nil {
-		return fmt.Errorf("failed to update user: %w", err)
+		return nil, fmt.Errorf("failed to update user: %w", err)
 	}
 
-	// Step 2: Ensure user is assigned to primary role via roles endpoint
+	// Step 2: Build the set of desired roles so we can remove stale ones.
+	desiredRoles := map[string]bool{primaryRole: true}
+	if !plan.SecondaryRole.IsNull() && !plan.SecondaryRole.IsUnknown() && plan.SecondaryRole.ValueString() != "" {
+		desiredRoles[plan.SecondaryRole.ValueString()] = true
+	}
+
+	// Step 3: Query the user's current role assignments and remove any
+	// that are no longer in the desired set. This mirrors the pattern
+	// used in the Delete method (getUserRoles + removeUserFromRole).
+	currentRoles, err := r.getUserRoles(ctx, username)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to query current roles for user %q: %s. "+
+			"Desired roles will be assigned but stale roles cannot be detected or removed. "+
+			"The device may retain role assignments that are no longer in the Terraform configuration.",
+			username, err.Error())
+		tflog.Warn(ctx, msg)
+		warnings = append(warnings, msg)
+	} else {
+		for _, role := range currentRoles {
+			if !desiredRoles[role] {
+				tflog.Info(ctx, "Removing stale role assignment", map[string]interface{}{
+					"username": username,
+					"role":     role,
+				})
+				removeErr := r.removeUserFromRole(ctx, username, role)
+				if removeErr != nil {
+					msg := fmt.Sprintf("Failed to remove stale role %q from user %q: %s. "+
+						"The device still retains this role assignment even though it is no longer in the Terraform configuration. "+
+						"A subsequent plan will not detect this drift because the Read path does not query role membership.",
+						role, username, removeErr.Error())
+					tflog.Warn(ctx, msg)
+					warnings = append(warnings, msg)
+				}
+			}
+		}
+	}
+
+	// Step 4: Ensure user is assigned to primary role via roles endpoint
 	tflog.Info(ctx, "Ensuring user is assigned to primary role", map[string]interface{}{
 		"username":     username,
 		"primary_role": primaryRole,
@@ -785,16 +827,14 @@ func (r *UserResource) updateUserWithRetry(ctx context.Context, username string,
 
 	err = r.assignUserToRole(ctx, username, primaryRole)
 	if err != nil {
-		tflog.Warn(ctx, "Failed to assign user to primary role during update",
-			map[string]interface{}{
-				"username":     username,
-				"primary_role": primaryRole,
-				"error":        err.Error(),
-			})
+		msg := fmt.Sprintf("Failed to assign primary role %q to user %q via roles endpoint: %s. "+
+			"The device may not reflect the intended role membership.", primaryRole, username, err.Error())
+		tflog.Warn(ctx, msg)
+		warnings = append(warnings, msg)
 	}
 
-	// Step 3: Manage secondary role assignment
-	if !plan.SecondaryRole.IsNull() && !plan.SecondaryRole.IsUnknown() && plan.SecondaryRole.ValueString() != "" {
+	// Step 5: Assign secondary role if specified
+	if desiredRoles[plan.SecondaryRole.ValueString()] {
 		secondaryRole := plan.SecondaryRole.ValueString()
 
 		tflog.Info(ctx, "Assigning secondary role to user", map[string]interface{}{
@@ -804,24 +844,14 @@ func (r *UserResource) updateUserWithRetry(ctx context.Context, username string,
 
 		err = r.assignUserToRole(ctx, username, secondaryRole)
 		if err != nil {
-			// If secondary role assignment fails, warn but don't fail the update
-			tflog.Warn(ctx, "Failed to assign secondary role during update",
-				map[string]interface{}{
-					"username":       username,
-					"secondary_role": secondaryRole,
-					"error":          err.Error(),
-				})
+			msg := fmt.Sprintf("Failed to assign secondary role %q to user %q: %s. "+
+				"The device may not reflect the intended role membership.", secondaryRole, username, err.Error())
+			tflog.Warn(ctx, msg)
+			warnings = append(warnings, msg)
 		}
-	} else {
-		// If secondary role is being removed, we might need to unassign it
-		// For now, we'll just log this - implementing role removal would require
-		// knowing the previous secondary role to remove the assignment
-		tflog.Info(ctx, "Secondary role not specified or being removed", map[string]interface{}{
-			"username": username,
-		})
 	}
 
-	return nil
+	return warnings, nil
 }
 
 // assignUserToRole assigns a user to a specific role using the roles endpoint

--- a/internal/provider/f5os_user_resource_test.go
+++ b/internal/provider/f5os_user_resource_test.go
@@ -1,11 +1,21 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
 
 func TestAccUserResource(t *testing.T) {
@@ -297,4 +307,730 @@ func TestAccUserResourceSecondaryRoleOnly(t *testing.T) {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test helpers for direct device verification
+// ---------------------------------------------------------------------------
+
+// newUserClientFromEnv creates a fresh f5osclient session from environment
+// variables. Port defaults to 8888 to match the provider.
+func newUserClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
+
+// testAccCheckUserRolesOnDevice queries the device's roles endpoint directly
+// and verifies that the given user has exactly the expected roles — no more,
+// no less. This bypasses the resource's Read method.
+func testAccCheckUserRolesOnDevice(username string, expectedRoles []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newUserClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		respData, err := client.GetRequest("/openconfig-system:system/aaa/authentication/f5-system-aaa:roles")
+		if err != nil {
+			return fmt.Errorf("failed to get roles from device: %w", err)
+		}
+
+		var rolesResponse struct {
+			Roles struct {
+				Role []struct {
+					RoleName string `json:"rolename"`
+					Config   struct {
+						Users []string `json:"users,omitempty"`
+					} `json:"config"`
+				} `json:"role"`
+			} `json:"f5-system-aaa:roles"`
+		}
+		if err := json.Unmarshal(respData, &rolesResponse); err != nil {
+			return fmt.Errorf("failed to parse roles response: %w", err)
+		}
+
+		// Find all roles the user belongs to
+		actualRoles := make(map[string]bool)
+		for _, role := range rolesResponse.Roles.Role {
+			for _, u := range role.Config.Users {
+				if u == username {
+					actualRoles[role.RoleName] = true
+				}
+			}
+		}
+
+		// Build expected set
+		expectedSet := make(map[string]bool)
+		for _, r := range expectedRoles {
+			expectedSet[r] = true
+		}
+
+		// Check for missing expected roles
+		for r := range expectedSet {
+			if !actualRoles[r] {
+				return fmt.Errorf("expected user %q to be in role %q on device, but they are not; actual roles: %v", username, r, actualRoles)
+			}
+		}
+		// Check for unexpected extra roles
+		for r := range actualRoles {
+			if !expectedSet[r] {
+				return fmt.Errorf("user %q has unexpected stale role %q on device; expected only: %v", username, r, expectedRoles)
+			}
+		}
+		return nil
+	}
+}
+
+// testAccCheckUserDestroy verifies all f5os_user resources in the state have
+// been deleted from the device.
+func testAccCheckUserDestroy(s *terraform.State) error {
+	client, err := newUserClientFromEnv()
+	if err != nil {
+		return nil // cannot connect — treat as destroyed
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "f5os_user" {
+			continue
+		}
+		username := rs.Primary.Attributes["username"]
+		uri := fmt.Sprintf("/openconfig-system:system/aaa/authentication/f5-system-aaa:users/user=%s", username)
+		respData, err := client.GetRequest(uri)
+		if err != nil {
+			continue // error means user is gone — that's good
+		}
+		// The SDK returns (body, nil) even for 404. Check the body for
+		// "not found" / "invalid-value" to distinguish 404 from 200.
+		body := string(respData)
+		if strings.Contains(body, "not found") || strings.Contains(body, "invalid-value") || body == "" {
+			continue // 404 response — user is gone
+		}
+		return fmt.Errorf("user %q still exists on device after destroy", username)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for stale role cleanup during Update
+// ---------------------------------------------------------------------------
+
+// TestAccUserRoleChangeRemovesStaleRole verifies on a real device that when a
+// user's primary role changes (e.g. operator -> resource-admin), the old role
+// assignment is removed. Without the fix, the user would accumulate in both
+// roles on the device.
+func TestAccUserRoleChangeRemovesStaleRole(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create user with role=operator
+			{
+				Config: testAccUserResourceConfig("acc_stale_role", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "username", "acc_stale_role"),
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+					testAccCheckUserRolesOnDevice("acc_stale_role", []string{"operator"}),
+				),
+			},
+			// Step 2: Change role to resource-admin — operator must be removed on the device
+			{
+				Config: testAccUserResourceConfig("acc_stale_role", "resource-admin"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "resource-admin"),
+					testAccCheckUserRolesOnDevice("acc_stale_role", []string{"resource-admin"}),
+				),
+			},
+			// Delete is automatic via CheckDestroy
+		},
+	})
+}
+
+// TestAccUserRoleChangeTwice verifies on a real device that changing the
+// primary role a second time also cleans up the intermediate role. This
+// exercises the stale-role cleanup over multiple update cycles.
+func TestAccUserRoleChangeTwice(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with role=operator
+			{
+				Config: testAccUserResourceConfig("acc_twice", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+					testAccCheckUserRolesOnDevice("acc_twice", []string{"operator"}),
+				),
+			},
+			// Step 2: Change to resource-admin — operator removed
+			{
+				Config: testAccUserResourceConfig("acc_twice", "resource-admin"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "resource-admin"),
+					testAccCheckUserRolesOnDevice("acc_twice", []string{"resource-admin"}),
+				),
+			},
+			// Step 3: Change back to operator — resource-admin removed
+			{
+				Config: testAccUserResourceConfig("acc_twice", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+					testAccCheckUserRolesOnDevice("acc_twice", []string{"operator"}),
+				),
+			},
+			// Delete is automatic via CheckDestroy
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Shared mock-server state for f5os_user unit tests
+// ---------------------------------------------------------------------------
+
+// userMockState holds mutable mock-server state shared across handlers.
+type userMockState struct {
+	mu sync.Mutex
+	// roleMembers tracks which users are assigned to which roles.
+	// key = rolename, value = set of usernames
+	roleMembers map[string]map[string]bool
+	// users tracks created users. key = username
+	users map[string]bool
+	// userConfigRole stores the role from the user config payload (create/update).
+	// This is the "primary role" that the GET user handler returns.
+	userConfigRole map[string]string
+	// roleRemovals records every (username, role) removal for assertions.
+	roleRemovals []roleRemovalRecord
+	// failGetRolesCount when > 0, the GET /f5-system-aaa:roles endpoint returns
+	// HTTP 500 and decrements the counter. This lets tests fail a specific number
+	// of getUserRoles calls while subsequent calls succeed (e.g., for Read).
+	failGetRolesCount int
+}
+
+type roleRemovalRecord struct {
+	Username string
+	Role     string
+}
+
+// setupUserMock registers all the standard mock handlers needed for
+// f5os_user unit tests and returns a pointer to the shared state.
+// The caller is responsible for calling teardown().
+//
+// initialRoles seeds the role membership table so that getUserRoles
+// returns the expected roles for a user.  Format: map[rolename][]username
+func setupUserMock(t *testing.T, initialRoles map[string][]string) *userMockState {
+	t.Helper()
+	testAccPreUnitCheck(t)
+
+	st := &userMockState{
+		roleMembers:    make(map[string]map[string]bool),
+		users:          make(map[string]bool),
+		userConfigRole: make(map[string]string),
+	}
+
+	// Seed initial role memberships
+	for role, users := range initialRoles {
+		st.roleMembers[role] = make(map[string]bool)
+		for _, u := range users {
+			st.roleMembers[role][u] = true
+		}
+	}
+
+	// --- Provider bootstrap handlers ---
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+
+	// --- Users endpoints: single handler dispatches on path + method ---
+	// http.ServeMux uses longest prefix matching, so we register the
+	// shortest common prefix and inspect the full path inside.
+
+	usersBase := "/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:users"
+
+	mux.HandleFunc(usersBase+"/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// set-password / change-password — POST to .../f5-system-aaa:user=<name>/...
+		if r.Method == "POST" && (strings.Contains(path, "set-password") || strings.Contains(path, "change-password")) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, "%s", "")
+			return
+		}
+
+		// Per-user: .../user=<username>
+		userPrefix := usersBase + "/user="
+		if len(path) > len(userPrefix) && path[:len(userPrefix)] == userPrefix {
+			username := path[len(userPrefix):]
+
+			st.mu.Lock()
+			defer st.mu.Unlock()
+
+			switch r.Method {
+			case "GET":
+				if !st.users[username] {
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value","error-message":"uri keypath not found"}]}}`)
+					return
+				}
+				// Use the stored config role for deterministic results
+				primaryRole := st.userConfigRole[username]
+				resp := fmt.Sprintf(`{"f5-system-aaa:user":[{"username":"%s","config":{"username":"%s","role":"%s"}}]}`, username, username, primaryRole)
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, "%s", resp)
+
+			case "PATCH":
+				if !st.users[username] {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				// Parse the payload to capture the updated role
+				var patchPayload struct {
+					User struct {
+						Config struct {
+							Role string `json:"role"`
+						} `json:"config"`
+					} `json:"f5-system-aaa:user"`
+				}
+				body, _ := io.ReadAll(r.Body)
+				if json.Unmarshal(body, &patchPayload) == nil && patchPayload.User.Config.Role != "" {
+					st.userConfigRole[username] = patchPayload.User.Config.Role
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, "%s", "")
+
+			case "DELETE":
+				delete(st.users, username)
+				for role := range st.roleMembers {
+					delete(st.roleMembers[role], username)
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, "%s", "")
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// Collection endpoint: POST to create user (exact path, no trailing sub-path)
+	mux.HandleFunc(usersBase, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			var payload struct {
+				User struct {
+					Username string `json:"username"`
+					Config   struct {
+						Username string `json:"username"`
+						Role     string `json:"role"`
+					} `json:"config"`
+				} `json:"f5-system-aaa:user"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			st.mu.Lock()
+			st.users[payload.User.Username] = true
+			if payload.User.Config.Role != "" {
+				st.userConfigRole[payload.User.Username] = payload.User.Config.Role
+			}
+			st.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprintf(w, "%s", "")
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	// --- Roles endpoints: single handler with subtree match ---
+	// Register with trailing "/" so http.ServeMux matches all sub-paths.
+	rolesBase := "/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:roles"
+
+	mux.HandleFunc(rolesBase+"/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// Per-role user assignment: PUT (assign) / DELETE (remove)
+		// Path: .../f5-system-aaa:role=<role>/f5-system-aaa:config/f5-system-aaa:users=<username>
+		rolePrefix := rolesBase + "/f5-system-aaa:role="
+		if strings.HasPrefix(path, rolePrefix) {
+			rest := path[len(rolePrefix):]
+			slashIdx := strings.Index(rest, "/")
+			if slashIdx < 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			roleName := rest[:slashIdx]
+			usersTag := "f5-system-aaa:users="
+			userIdx := strings.Index(rest, usersTag)
+			if userIdx < 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			username := rest[userIdx+len(usersTag):]
+
+			st.mu.Lock()
+			defer st.mu.Unlock()
+
+			switch r.Method {
+			case "PUT":
+				if st.roleMembers[roleName] == nil {
+					st.roleMembers[roleName] = make(map[string]bool)
+				}
+				st.roleMembers[roleName][username] = true
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, "%s", "")
+
+			case "DELETE":
+				if members, ok := st.roleMembers[roleName]; ok {
+					delete(members, username)
+				}
+				st.roleRemovals = append(st.roleRemovals, roleRemovalRecord{Username: username, Role: roleName})
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, "%s", "")
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// GET all roles — exact path match (no trailing /)
+	mux.HandleFunc(rolesBase, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		st.mu.Lock()
+		defer st.mu.Unlock()
+
+		if st.failGetRolesCount > 0 {
+			st.failGetRolesCount--
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"operation-failed","error-message":"simulated roles endpoint failure"}]}}`)
+			return
+		}
+
+		type roleConfig struct {
+			Users []string `json:"users,omitempty"`
+		}
+		type roleEntry struct {
+			RoleName string     `json:"rolename"`
+			Config   roleConfig `json:"config"`
+		}
+		type rolesWrapper struct {
+			Roles struct {
+				Role []roleEntry `json:"role"`
+			} `json:"f5-system-aaa:roles"`
+		}
+
+		var resp rolesWrapper
+		allRoles := map[string]bool{"admin": true, "operator": true, "resource-admin": true, "user": true}
+		for role := range st.roleMembers {
+			allRoles[role] = true
+		}
+		sortedRoles := make([]string, 0, len(allRoles))
+		for role := range allRoles {
+			sortedRoles = append(sortedRoles, role)
+		}
+		sort.Strings(sortedRoles)
+		for _, role := range sortedRoles {
+			entry := roleEntry{RoleName: role}
+			if members, ok := st.roleMembers[role]; ok {
+				sortedMembers := make([]string, 0, len(members))
+				for u := range members {
+					sortedMembers = append(sortedMembers, u)
+				}
+				sort.Strings(sortedMembers)
+				entry.Config.Users = sortedMembers
+			}
+			resp.Roles.Role = append(resp.Roles.Role, entry)
+		}
+
+		body, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	return st
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for stale role cleanup during Update
+// ---------------------------------------------------------------------------
+
+// TestUnitUserRoleChangeRemovesStaleRole verifies that when a user's primary
+// role changes (e.g. operator -> admin), the old role assignment is removed
+// before the new one is assigned. Without the fix, the user would accumulate
+// in both roles.
+func TestUnitUserRoleChangeRemovesStaleRole(t *testing.T) {
+	st := setupUserMock(t, map[string][]string{
+		"operator": {"unittest_rolechange"},
+	})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create user with role=operator
+			{
+				Config: testAccUserResourceConfig("unittest_rolechange", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "username", "unittest_rolechange"),
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+				),
+			},
+			// Step 2: Change role to admin — operator should be removed
+			{
+				Config: testAccUserResourceConfig("unittest_rolechange", "admin"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "admin"),
+					func(s *terraform.State) error {
+						st.mu.Lock()
+						defer st.mu.Unlock()
+
+						// Verify operator was removed
+						operatorRemoved := false
+						for _, removal := range st.roleRemovals {
+							if removal.Username == "unittest_rolechange" && removal.Role == "operator" {
+								operatorRemoved = true
+								break
+							}
+						}
+						if !operatorRemoved {
+							return fmt.Errorf("expected stale role 'operator' to be removed for user 'unittest_rolechange', but no removal was recorded; removals: %+v", st.roleRemovals)
+						}
+
+						// Verify user is now in admin role only
+						if !st.roleMembers["admin"]["unittest_rolechange"] {
+							return fmt.Errorf("expected user 'unittest_rolechange' to be in 'admin' role")
+						}
+						if st.roleMembers["operator"]["unittest_rolechange"] {
+							return fmt.Errorf("expected user 'unittest_rolechange' to NOT be in 'operator' role after role change")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitUserSecondaryRoleRemovalCleansUp verifies that when a user's
+// secondary_role is removed from the config, the old secondary role
+// assignment is cleaned up on the device.
+func TestUnitUserSecondaryRoleRemovalCleansUp(t *testing.T) {
+	st := setupUserMock(t, map[string][]string{
+		"admin":    {"unittest_secrole"},
+		"operator": {"unittest_secrole"},
+	})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with primary=admin, secondary=operator
+			{
+				Config: testAccUserResourceConfigWithSecondaryRole("unittest_secrole", "admin", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "admin"),
+					resource.TestCheckResourceAttr("f5os_user.test", "secondary_role", "operator"),
+				),
+			},
+			// Step 2: Remove secondary_role — operator should be removed
+			{
+				Config: testAccUserResourceConfig("unittest_secrole", "admin"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "admin"),
+					func(s *terraform.State) error {
+						st.mu.Lock()
+						defer st.mu.Unlock()
+
+						// Verify operator was removed
+						operatorRemoved := false
+						for _, removal := range st.roleRemovals {
+							if removal.Username == "unittest_secrole" && removal.Role == "operator" {
+								operatorRemoved = true
+								break
+							}
+						}
+						if !operatorRemoved {
+							return fmt.Errorf("expected secondary role 'operator' to be removed for user 'unittest_secrole', but no removal was recorded; removals: %+v", st.roleRemovals)
+						}
+
+						// Verify user is in admin only
+						if !st.roleMembers["admin"]["unittest_secrole"] {
+							return fmt.Errorf("expected user to remain in 'admin' role")
+						}
+						if st.roleMembers["operator"]["unittest_secrole"] {
+							return fmt.Errorf("expected user to NOT be in 'operator' role after secondary role removal")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitUserSameRolesNoRemoval verifies that when a user's roles don't
+// change during an update (e.g. only password changes), no role removals
+// are triggered.
+func TestUnitUserSameRolesNoRemoval(t *testing.T) {
+	st := setupUserMock(t, map[string][]string{
+		"operator": {"unittest_norole"},
+	})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with role=operator
+			{
+				Config: testAccUserResourceConfig("unittest_norole", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+				),
+			},
+			// Step 2: "Update" with same role — no removals should occur
+			{
+				Config: testUnitUserResourceConfigDifferentPassword("unittest_norole", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+					func(s *terraform.State) error {
+						st.mu.Lock()
+						defer st.mu.Unlock()
+
+						// Filter removals for this user
+						for _, removal := range st.roleRemovals {
+							if removal.Username == "unittest_norole" {
+								return fmt.Errorf("expected no role removals for user 'unittest_norole' when roles unchanged, but got removal of role %q", removal.Role)
+							}
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitUserGetRolesFailureDuringUpdate verifies that when getUserRoles()
+// fails during Update (e.g. the roles endpoint returns HTTP 500), the Update
+// still succeeds — the failure is logged as a warning, the new role is
+// assigned, but stale roles cannot be removed because the current role set
+// is unknown. This tests the graceful degradation path at
+// f5os_user_resource.go:789-795.
+func TestUnitUserGetRolesFailureDuringUpdate(t *testing.T) {
+	st := setupUserMock(t, map[string][]string{
+		"operator": {"unittest_getfail"},
+	})
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create user with role=operator (roles endpoint works)
+			{
+				Config: testAccUserResourceConfig("unittest_getfail", "operator"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_user.test", "username", "unittest_getfail"),
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "operator"),
+				),
+			},
+			// Step 2: Change role to admin while roles endpoint fails.
+			// getUserRoles returns an error, so stale role cleanup is skipped.
+			// But the update itself must still succeed — the new role is
+			// assigned and state is saved.
+			{
+				PreConfig: func() {
+					st.mu.Lock()
+					// The SDK retries each request 3 times with 10s delay.
+					// Before the Update apply, the framework calls Read which
+					// also invokes getUserRoles (consuming retries from the
+					// counter). We set the counter high enough to fail ALL
+					// getUserRoles calls during this step — both the Read
+					// refresh and the Update's own call. The post-apply Read
+					// may also fail, producing a non-empty plan, which we
+					// tolerate with ExpectNonEmptyPlan.
+					st.failGetRolesCount = 9
+					st.mu.Unlock()
+				},
+				Config:             testAccUserResourceConfig("unittest_getfail", "admin"),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Update must succeed — Terraform state reflects new role
+					resource.TestCheckResourceAttr("f5os_user.test", "role", "admin"),
+					func(s *terraform.State) error {
+						st.mu.Lock()
+						defer st.mu.Unlock()
+
+						// No role removals should have occurred because
+						// getUserRoles failed — we couldn't determine the
+						// current roles to compare against.
+						for _, removal := range st.roleRemovals {
+							if removal.Username == "unittest_getfail" {
+								return fmt.Errorf("expected no role removals when getUserRoles fails, but got removal of role %q", removal.Role)
+							}
+						}
+
+						// The user should still be in the operator role
+						// (stale, not cleaned up) AND in admin (newly assigned).
+						if !st.roleMembers["admin"]["unittest_getfail"] {
+							return fmt.Errorf("expected user to be assigned to 'admin' role")
+						}
+						if !st.roleMembers["operator"]["unittest_getfail"] {
+							return fmt.Errorf("expected user to still be in stale 'operator' role (removal was skipped due to getUserRoles failure)")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// testUnitUserResourceConfigDifferentPassword generates a config with a
+// different password to force a Terraform update without changing roles.
+func testUnitUserResourceConfigDifferentPassword(username, role string) string {
+	return fmt.Sprintf(`
+resource "f5os_user" "test" {
+  username = %[1]q
+  password = "DifferentP@ss456"
+  role     = %[2]q
+}
+`, username, role)
 }

--- a/internal/provider/fixtures/f5os_auth_v17.json
+++ b/internal/provider/fixtures/f5os_auth_v17.json
@@ -1,0 +1,122 @@
+{
+  "openconfig-system:aaa": {
+    "authentication": {
+      "f5-openconfig-aaa-ldap:ldap": {
+        "bind_timelimit": 10,
+        "timelimit": 0,
+        "idle_timelimit": 0,
+        "ldap_version": 3,
+        "ssl": "off",
+        "active_directory": false,
+        "tls_reqcert": "demand"
+      },
+      "f5-system-aaa:users": {
+        "user": [
+          {
+            "username": "admin",
+            "config": {
+              "username": "admin",
+              "last-change": 19433,
+              "tally-count": 0,
+              "expiry-date": "-1",
+              "role": "admin"
+            },
+            "state": {
+              "username": "admin",
+              "last-change": 19433,
+              "tally-count": 0,
+              "expiry-date": "-1",
+              "role": "admin"
+            }
+          },
+          {
+            "username": "root",
+            "config": {
+              "username": "root",
+              "last-change": 0,
+              "tally-count": 0,
+              "expiry-date": "-1",
+              "role": "root"
+            },
+            "state": {
+              "username": "root",
+              "last-change": 0,
+              "tally-count": 0,
+              "expiry-date": "-1",
+              "role": "root"
+            }
+          }
+        ]
+      },
+      "f5-system-aaa:roles": {
+        "role": [
+          {
+            "rolename": "admin",
+            "config": {
+              "rolename": "admin",
+              "gid": 9000
+            },
+            "state": {
+              "rolename": "admin",
+              "gid": 9000
+            }
+          },
+          {
+            "rolename": "operator",
+            "config": {
+              "rolename": "operator",
+              "gid": 9001
+            },
+            "state": {
+              "rolename": "operator",
+              "gid": 9001
+            }
+          },
+          {
+            "rolename": "root",
+            "config": {
+              "rolename": "root",
+              "gid": 0
+            },
+            "state": {
+              "rolename": "root",
+              "gid": 0
+            }
+          },
+          {
+            "rolename": "tenant-console",
+            "config": {
+              "rolename": "tenant-console",
+              "gid": 9100
+            },
+            "state": {
+              "rolename": "tenant-console",
+              "gid": 9100
+            }
+          }
+        ]
+      }
+    },
+    "f5-openconfig-aaa-password-policy:password-policy": {
+      "config": {
+        "min-length": 6,
+        "required-numeric": 0,
+        "required-uppercase": 0,
+        "required-lowercase": 0,
+        "required-special": 0,
+        "max-letter-repeat": 3,
+        "max-sequence-repeat": 0,
+        "max-class-repeat": 0,
+        "required-differences": 8,
+        "reject-username": false,
+        "apply-to-root": true,
+        "retries": 3,
+        "max-login-failures": 10,
+        "unlock-time": 60,
+        "root-lockout": true,
+        "root-unlock-time": 60,
+        "max-age": 0
+      }
+    }
+  }
+}

--- a/internal/provider/fixtures/platform_components_rseries.json
+++ b/internal/provider/fixtures/platform_components_rseries.json
@@ -1,0 +1,19 @@
+{
+  "openconfig-platform:component": [
+    {
+      "name": "lcd",
+      "config": { "name": "lcd" },
+      "state": { "empty": false }
+    },
+    {
+      "name": "platform",
+      "config": { "name": "platform" },
+      "state": {
+        "description": "rSeries Platform",
+        "serial-no": "mock-serial",
+        "part-no": "mock-part",
+        "empty": false
+      }
+    }
+  ]
+}

--- a/internal/provider/fixtures/tenant_config_multi_vlans.json
+++ b/internal/provider/fixtures/tenant_config_multi_vlans.json
@@ -1,0 +1,61 @@
+{
+  "f5-tenants:tenant": [
+    {
+      "name": "testtenant-ecosys2",
+      "config": {
+        "name": "testtenant-ecosys2",
+        "type": "BIG-IP",
+        "image": "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle",
+        "nodes": [
+          1
+        ],
+        "mgmt-ip": "10.10.10.26",
+        "prefix-length": 24,
+        "gateway": "10.10.10.1",
+        "dag-ipv6-prefix-length": 128,
+        "vlans": [10, 20, 30],
+        "cryptos": "enabled",
+        "tenant-auth-support": "disabled",
+        "vcpu-cores-per-node": 8,
+        "memory": "29184",
+        "storage": {
+          "size": 82
+        },
+        "running-state": "configured",
+        "appliance-mode": {
+          "enabled": false
+        }
+      },
+      "state": {
+        "name": "testtenant-ecosys2",
+        "unit-key-hash": "pbsgB3yQXv/RJb69mwMs8OPfLR3zNJATzdFq/07JsBnjQElAl+DKKJQMZ/Nur0myc1KG4tK4THaS54y4SQAIyQ==",
+        "type": "BIG-IP",
+        "image": "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle",
+        "nodes": [
+          1
+        ],
+        "mgmt-ip": "10.10.10.26",
+        "prefix-length": 24,
+        "dag-ipv6-prefix-length": 128,
+        "gateway": "10.10.10.1",
+        "vlans": [10, 20, 30],
+        "cryptos": "enabled",
+        "tenant-auth-support": "disabled",
+        "vcpu-cores-per-node": 8,
+        "memory": "29184",
+        "storage": {
+          "size": 82
+        },
+        "running-state": "configured",
+        "mac-data": {
+          "base-mac": "f4:15:63:fb:a0:1a",
+          "mac-pool-size": 1
+        },
+        "appliance-mode": {
+          "enabled": false
+        },
+        "status": "Configured"
+      }
+    }
+  ]
+}

--- a/internal/provider/fixtures/tenant_config_no_vlans.json
+++ b/internal/provider/fixtures/tenant_config_no_vlans.json
@@ -1,0 +1,59 @@
+{
+  "f5-tenants:tenant": [
+    {
+      "name": "testtenant-ecosys2",
+      "config": {
+        "name": "testtenant-ecosys2",
+        "type": "BIG-IP",
+        "image": "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle",
+        "nodes": [
+          1
+        ],
+        "mgmt-ip": "10.10.10.26",
+        "prefix-length": 24,
+        "gateway": "10.10.10.1",
+        "dag-ipv6-prefix-length": 128,
+        "cryptos": "enabled",
+        "tenant-auth-support": "disabled",
+        "vcpu-cores-per-node": 8,
+        "memory": "29184",
+        "storage": {
+          "size": 82
+        },
+        "running-state": "configured",
+        "appliance-mode": {
+          "enabled": false
+        }
+      },
+      "state": {
+        "name": "testtenant-ecosys2",
+        "unit-key-hash": "pbsgB3yQXv/RJb69mwMs8OPfLR3zNJATzdFq/07JsBnjQElAl+DKKJQMZ/Nur0myc1KG4tK4THaS54y4SQAIyQ==",
+        "type": "BIG-IP",
+        "image": "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle",
+        "nodes": [
+          1
+        ],
+        "mgmt-ip": "10.10.10.26",
+        "prefix-length": 24,
+        "dag-ipv6-prefix-length": 128,
+        "gateway": "10.10.10.1",
+        "cryptos": "enabled",
+        "tenant-auth-support": "disabled",
+        "vcpu-cores-per-node": 8,
+        "memory": "29184",
+        "storage": {
+          "size": 82
+        },
+        "running-state": "configured",
+        "mac-data": {
+          "base-mac": "f4:15:63:fb:a0:1a",
+          "mac-pool-size": 1
+        },
+        "appliance-mode": {
+          "enabled": false
+        },
+        "status": "Configured"
+      }
+    }
+  ]
+}

--- a/internal/provider/fixtures/tenant_image_transfer_status.json
+++ b/internal/provider/fixtures/tenant_image_transfer_status.json
@@ -48,7 +48,16 @@
         },
         {
             "local-file-path": "images/tenant/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
-            "remote-host": "spkapexsrvc01.olympus.f5net.com",
+            "remote-host": "10.238.1.148",
+            "remote-file-path": "v17.1.0.1/dist/release/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "operation": "Import file",
+            "protocol": "HTTPS   ",
+            "status": "         Completed",
+            "timestamp": "Mon Jun 26 16:05:22 2023"
+        },
+        {
+            "local-file-path": "images/tenant/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "remote-host": "10.238.1.148",
             "remote-file-path": "v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
             "operation": "Import file",
             "protocol": "HTTPS   ",
@@ -57,7 +66,7 @@
         },
         {
             "local-file-path": "images/tenant/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
-            "remote-host": "spkapexsrvc01.olympus.f5net.com",
+            "remote-host": "10.238.1.148",
             "remote-file-path": "v17.1.0.1/daily/release/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
             "operation": "Import file",
             "protocol": "HTTPS   ",

--- a/internal/provider/interface_resource_test.go
+++ b/internal/provider/interface_resource_test.go
@@ -77,7 +77,7 @@ func TestAccInterfaceCreateTC2Resource(t *testing.T) {
 	})
 }
 
-func TestAccInterfaceCreateUnitTC3Resource(t *testing.T) {
+func TestUnitInterfaceCreateTC3Resource(t *testing.T) {
 	// Define our mocked connection object
 	testAccPreUnitCheck(t)
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +132,7 @@ func TestAccInterfaceCreateUnitTC3Resource(t *testing.T) {
 	})
 }
 
-func TestAccInterfaceCreateUnitTC4Resource(t *testing.T) {
+func TestUnitInterfaceCreateTC4Resource(t *testing.T) {
 	// Define our mocked connection object
 	testAccPreUnitCheck(t)
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/provider/lag_resource_test.go
+++ b/internal/provider/lag_resource_test.go
@@ -79,7 +79,7 @@ func TestAccLagInterfaceCreateTC2Resource(t *testing.T) {
 	})
 }
 
-func TestAccLagInterfaceCreateUnitTC3Resource(t *testing.T) {
+func TestUnitLagInterfaceCreateTC3Resource(t *testing.T) {
 	// Define our mocked connection object
 	testAccPreUnitCheck(t)
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
@@ -139,7 +139,7 @@ func TestAccLagInterfaceCreateUnitTC3Resource(t *testing.T) {
 	})
 }
 
-func TestAccLagInterfaceCreateUnitTC4Resource(t *testing.T) {
+func TestUnitLagInterfaceCreateTC4Resource(t *testing.T) {
 	// Define our mocked connection object
 	testAccPreUnitCheck(t)
 	count := 0

--- a/internal/provider/partition_change_password_resource_test.go
+++ b/internal/provider/partition_change_password_resource_test.go
@@ -1,0 +1,207 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// ---------------------------------------------------------------------------
+// Acceptance tests (real device)
+// ---------------------------------------------------------------------------
+
+// TestAccPartitionChangePasswordRejectsRSeries verifies that the resource
+// correctly rejects rSeries platforms with a clear error message. The
+// f5os_partition_change_password resource is VELOS-partition-only.
+func TestAccPartitionChangePasswordRejectsRSeries(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckPlatformRSeries(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPartitionChangePasswordConfig("testuser", "old_pass_123", "new_pass_456"),
+				ExpectError: regexp.MustCompile(`(?s)supported with Velos Partition`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (mock server)
+// ---------------------------------------------------------------------------
+
+// TestUnitPartitionChangePasswordVelosPartitionSuccess simulates a VELOS
+// partition environment and verifies the full Create code path succeeds.
+func TestUnitPartitionChangePasswordVelosPartitionSuccess(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	// Mock: platform detection — returns a single component so the SDK
+	// classifies this as "Velos Partition" (len == 1 branch).
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"openconfig-platform:component": [
+				{
+					"name": "blade-1",
+					"state": {
+						"name": "blade-1"
+					}
+				}
+			]
+		}`))
+	})
+
+	// Mock: aaa endpoint (provider Configure reads this)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	// Mock: change-password endpoint
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:users/f5-system-aaa:user=testuser/f5-system-aaa:config/f5-system-aaa:change-password", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if _, ok := body["f5-system-aaa:old-password"]; !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error": "missing old-password"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create — exercises the Create code path.
+			{
+				Config: testAccPartitionChangePasswordConfig("testuser", "OldP@ssw0rd!", "NewP@ssw0rd!"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_partition_change_password.test", "user_name", "testuser"),
+					resource.TestCheckResourceAttr("f5os_partition_change_password.test", "id", "testuser"),
+				),
+			},
+			// Step 2: Update — changing passwords triggers the Update
+			// code path (user_name has RequiresReplace, but passwords
+			// do not, so Terraform calls Update, not destroy+create).
+			{
+				Config: testAccPartitionChangePasswordConfig("testuser", "NewP@ssw0rd!", "EvenN3wer!"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_partition_change_password.test", "user_name", "testuser"),
+					resource.TestCheckResourceAttr("f5os_partition_change_password.test", "id", "testuser"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPartitionChangePasswordPlatformRejection verifies the resource
+// rejects non-VELOS platforms using a mock that returns an rSeries response.
+func TestUnitPartitionChangePasswordPlatformRejection(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	// Reuse shared helper to register rSeries platform + version mock handlers.
+	setupMockPlatformVersion(mux, "1.5.4-37447")
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPartitionChangePasswordConfig("testuser", "OldP@ssw0rd!", "NewP@ssw0rd!"),
+				ExpectError: regexp.MustCompile(`(?s)supported with Velos Partition`),
+			},
+		},
+	})
+}
+
+// TestUnitPartitionChangePasswordAPIError verifies that API errors from the
+// change-password endpoint are surfaced to the user.
+func TestUnitPartitionChangePasswordAPIError(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	// Mock: Velos Partition platform (single component)
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"openconfig-platform:component": [
+				{
+					"name": "blade-1",
+					"state": {
+						"name": "blade-1"
+					}
+				}
+			]
+		}`))
+	})
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	// Mock: change-password returns an error
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/authentication/f5-system-aaa:users/f5-system-aaa:user=testuser/f5-system-aaa:config/f5-system-aaa:change-password", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{
+			"ietf-restconf:errors": {
+				"error": [{
+					"error-type": "application",
+					"error-tag": "invalid-value",
+					"error-message": "Old password is incorrect"
+				}]
+			}
+		}`))
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPartitionChangePasswordConfig("testuser", "WrongP@ss!", "NewP@ssw0rd!"),
+				ExpectError: regexp.MustCompile(`Partition Password change failed`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Config helper
+// ---------------------------------------------------------------------------
+
+func testAccPartitionChangePasswordConfig(userName, oldPassword, newPassword string) string {
+	return fmt.Sprintf(`
+resource "f5os_partition_change_password" "test" {
+  user_name    = %[1]q
+  old_password = %[2]q
+  new_password = %[3]q
+}
+`, userName, oldPassword, newPassword)
+}

--- a/internal/provider/primarykey_resource.go
+++ b/internal/provider/primarykey_resource.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -104,6 +106,65 @@ func (r *PrimaryKeyResource) Configure(ctx context.Context, req resource.Configu
 	r.teemData = teemData
 }
 
+// primaryKeyPollInterval is the delay between status-check attempts.
+// Overridden in tests to avoid real wall-clock waits.
+var primaryKeyPollInterval = 2 * time.Second
+
+// primaryKeyMigrationTimeout is the maximum time to wait for COMPLETE status.
+// Overridden in tests to keep suite fast.
+var primaryKeyMigrationTimeout = 60 * time.Second
+
+// primaryKeyInitialReadDelay gives the device time to settle after SetPrimaryKey
+// before the polling loop begins. Overridden in tests to avoid wall-clock sleeps.
+var primaryKeyInitialReadDelay = 5 * time.Second
+
+// waitForPrimaryKeyMigration polls GetPrimaryKey until status is COMPLETE or
+// primaryKeyMigrationTimeout elapses.
+func (r *PrimaryKeyResource) waitForPrimaryKeyMigration(ctx context.Context) error {
+	maxPolls := int(primaryKeyMigrationTimeout / primaryKeyPollInterval)
+	if maxPolls < 1 {
+		maxPolls = 1
+	}
+
+	tflog.Info(ctx, "Waiting for primary key migration to complete")
+
+	if primaryKeyInitialReadDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for primary key migration")
+		case <-time.After(primaryKeyInitialReadDelay):
+		}
+	}
+
+	for poll := 0; poll < maxPolls; poll++ {
+		keyData, err := r.client.GetPrimaryKey()
+		switch {
+		case err != nil:
+			tflog.Warn(ctx, fmt.Sprintf("Error polling primary key status: %s", err))
+		case keyData == nil:
+			tflog.Warn(ctx, "Error polling primary key status: empty response from device")
+		default:
+			status := keyData.PrimaryKey.State.Status
+			tflog.Debug(ctx, fmt.Sprintf("Primary key migration status: %s", status))
+			if strings.Contains(status, "COMPLETE") {
+				tflog.Info(ctx, "Primary key migration completed successfully")
+				return nil
+			}
+		}
+
+		// Sleep before the next poll (skip sleep on the last iteration)
+		if poll < maxPolls-1 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled while waiting for primary key migration")
+			case <-time.After(primaryKeyPollInterval):
+			}
+		}
+	}
+
+	return fmt.Errorf("primary key migration did not complete within %s", primaryKeyMigrationTimeout)
+}
+
 func (r *PrimaryKeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data *PrimaryKeyResourceModel
 
@@ -119,21 +180,18 @@ func (r *PrimaryKeyResource) Create(ctx context.Context, req resource.CreateRequ
 
 	_ = r.client.SendTeem(map[string]any{"teemData": r.teemData})
 
-	// Skip if already present and not forced
-	if !data.ForceUpdate.ValueBool() {
-		existing, err := r.client.GetPrimaryKey()
-		if err == nil && existing.PrimaryKey.State.Status != "" {
-			tflog.Info(ctx, "[CREATE] Skipping creation as primary key exists and force_update is false")
-			r.primaryKeyResourceModelToState(existing, data)
-			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-			return
-		}
-	}
-
-	// Set the key
+	// Always set the key on Create. Create is only called for new or
+	// recreated resources (passphrase/salt have RequiresReplace), so
+	// SetPrimaryKey must always run to apply the configured credentials.
 	_, err := r.client.SetPrimaryKey(primaryKeyReq)
 	if err != nil {
 		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to create PrimaryKey: %s", err))
+		return
+	}
+
+	// Wait for async migration to complete before reading state
+	if err := r.waitForPrimaryKeyMigration(ctx); err != nil {
+		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Primary key migration failed: %s", err))
 		return
 	}
 
@@ -141,6 +199,10 @@ func (r *PrimaryKeyResource) Create(ctx context.Context, req resource.CreateRequ
 	keyData, err := r.client.GetPrimaryKey()
 	if err != nil {
 		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to fetch state after setting PrimaryKey: %s", err))
+		return
+	}
+	if keyData == nil {
+		resp.Diagnostics.AddError("F5OS Client Error", "Failed to fetch state after setting PrimaryKey: empty response from device")
 		return
 	}
 
@@ -165,6 +227,10 @@ func (r *PrimaryKeyResource) Read(ctx context.Context, req resource.ReadRequest,
 		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to fetch Primary Key configuration: %s", err))
 		return
 	}
+	if keyData == nil {
+		resp.Diagnostics.AddError("F5OS Client Error", "Failed to fetch Primary Key configuration: empty response from device")
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("PrimaryKey Response: %+v", keyData))
 
@@ -186,21 +252,34 @@ func (r *PrimaryKeyResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	tflog.Info(ctx, "[UPDATE] Updating Primary Key configuration")
 
-	// Prepare request payload
-	keyReqConfig := getPrimaryKeyConfig(data)
-	tflog.Debug(ctx, fmt.Sprintf("PrimaryKey Update Payload: %+v", keyReqConfig))
+	if data.ForceUpdate.ValueBool() {
+		// Only re-key when force_update=true. Changing force_update alone
+		// (false → true) is the user's explicit signal to rotate the key.
+		keyReqConfig := getPrimaryKeyConfig(data)
+		tflog.Debug(ctx, fmt.Sprintf("PrimaryKey Update Payload: %+v", keyReqConfig))
 
-	// Send the update to the F5OS system
-	_, err := r.client.SetPrimaryKey(keyReqConfig) // Use SetPrimaryKey as this acts as upsert
-	if err != nil {
-		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to update Primary Key: %s", err))
-		return
+		_, err := r.client.SetPrimaryKey(keyReqConfig)
+		if err != nil {
+			resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to update Primary Key: %s", err))
+			return
+		}
+
+		if err := r.waitForPrimaryKeyMigration(ctx); err != nil {
+			resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Primary key migration failed: %s", err))
+			return
+		}
+	} else {
+		tflog.Info(ctx, "[UPDATE] force_update=false — skipping SetPrimaryKey, refreshing state only")
 	}
 
 	// Fetch the latest status after update
 	keyData, err := r.client.GetPrimaryKey()
 	if err != nil {
 		resp.Diagnostics.AddError("F5OS Client Error", fmt.Sprintf("Failed to retrieve Primary Key after update: %s", err))
+		return
+	}
+	if keyData == nil {
+		resp.Diagnostics.AddError("F5OS Client Error", "Failed to retrieve Primary Key after update: empty response from device")
 		return
 	}
 

--- a/internal/provider/primarykey_resource_test.go
+++ b/internal/provider/primarykey_resource_test.go
@@ -1,13 +1,93 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"regexp"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/stretchr/testify/assert"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
 
+func withFastPolling(t *testing.T) {
+	origInterval := primaryKeyPollInterval
+	origTimeout := primaryKeyMigrationTimeout
+	origDelay := primaryKeyInitialReadDelay
+
+	primaryKeyPollInterval = 10 * time.Millisecond
+	primaryKeyMigrationTimeout = 100 * time.Millisecond
+	primaryKeyInitialReadDelay = 0
+
+	t.Cleanup(func() {
+		primaryKeyPollInterval = origInterval
+		primaryKeyMigrationTimeout = origTimeout
+		primaryKeyInitialReadDelay = origDelay
+	})
+}
+
+// primaryKeyResponse is the correct API response format after the JSON tag fix.
+// The nested fields use bare keys ("state", "hash", "status"), not namespace-prefixed ones.
+const primaryKeyResponseCorrect = `{
+	"f5-primary-key:primary-key": {
+		"state": {
+			"hash":   "abc123hash",
+			"status": "COMPLETE"
+		}
+	}
+}`
+
+// primaryKeyResponseOldFormat is what the API actually returns before the fix
+// was understood — nested keys were incorrectly prefixed with "f5-primary-key:".
+// json.Unmarshal silently ignores unknown keys, so hash and status were always "".
+const primaryKeyResponseOldFormat = `{
+	"f5-primary-key:primary-key": {
+		"f5-primary-key:state": {
+			"f5-primary-key:hash":   "abc123hash",
+			"f5-primary-key:status": "COMPLETE"
+		}
+	}
+}`
+
+// setupPrimaryKeyMock registers the standard provider bootstrap handlers and
+// the primary-key endpoint handlers. responseJSON controls the GET response.
+// setCounter is incremented on every POST to the .../f5-primary-key:set
+// endpoint (SetPrimaryKey). Caller must defer teardown().
+func setupPrimaryKeyMock(t *testing.T, responseJSON string, setCounter *int32) {
+	t.Helper()
+	testAccPreUnitCheck(t)
+
+	// GET primary-key state
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("unexpected HTTP method on primary-key endpoint: %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseJSON))
+	})
+
+	// POST SetPrimaryKey (separate path: .../f5-primary-key:set)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key/f5-primary-key:set", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("unexpected HTTP method on set endpoint: %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if setCounter != nil {
+			atomic.AddInt32(setCounter, 1)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+}
+
+// TestAccPrimaryKeyResource is the real-device acceptance test (unchanged).
 func TestAccPrimaryKeyResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -25,33 +105,87 @@ func TestAccPrimaryKeyResource(t *testing.T) {
 	})
 }
 
-func TestUnitPrimaryKeyResource(t *testing.T) {
-	testAccPreUnitCheck(t)
-
-	// Combined handler for GET and PATCH on the same path
-	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key", func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case "GET":
-			assert.Equal(t, "GET", r.Method)
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
-				"f5-primary-key:primary-key": {
-					"f5-primary-key:state": {
-						"f5-primary-key:hash": "abc123hash",
-						"f5-primary-key:status": "COMPLETE"
-					}
-				}
-			}`))
-		case "PATCH":
-			assert.Equal(t, "PATCH", r.Method)
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
-		default:
-			t.Errorf("Unexpected HTTP method: %s", r.Method)
-			w.WriteHeader(http.StatusMethodNotAllowed)
-		}
+// TestAccPrimaryKeyHashStatusPopulated verifies on a real device that Create
+// with force_update=true correctly populates hash and status in Terraform state.
+// Before the JSON tag fix, both fields were always empty regardless of what the
+// device returned. This is the primary regression test for the deserialization
+// fix on real hardware.
+func TestAccPrimaryKeyHashStatusPopulated(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryKeyResourceConfig, // force_update=true
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "id", "primary-key"),
+					// Before the fix these would both be empty strings.
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "hash"),
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "status"),
+				),
+			},
+		},
 	})
+}
 
+// TestAccPrimaryKeyForceUpdateChange verifies on a real device that changing
+// force_update from true to false triggers the Update method, which calls
+// SetPrimaryKey and then re-reads hash and status. Both fields must remain
+// populated after the update.
+func TestAccPrimaryKeyForceUpdateChange(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with force_update=true
+			{
+				Config: testAccPrimaryKeyResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "true"),
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "hash"),
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "status"),
+				),
+			},
+			// Step 2: Update force_update=false — triggers Update method, hash/status must persist
+			{
+				Config: testAccPrimaryKeyResourceNoForceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "false"),
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "hash"),
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "status"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPrimaryKeyCreateAlwaysSetsOnDevice verifies on a real device that
+// Create with force_update=false still calls SetPrimaryKey and populates
+// hash and status. Create must always apply the configured passphrase/salt
+// because it only runs on new or recreated resources.
+func TestAccPrimaryKeyCreateAlwaysSetsOnDevice(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryKeyResourceNoForceConfig, // force_update=false
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "false"),
+					// Create always calls SetPrimaryKey — hash and status must be populated
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "hash"),
+					resource.TestCheckResourceAttrSet("f5os_primarykey.default", "status"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyResource is the existing Create unit test, updated to use
+// the correct JSON format that matches the fixed struct tags.
+func TestUnitPrimaryKeyResource(t *testing.T) {
+	withFastPolling(t)
+	setupPrimaryKeyMock(t, primaryKeyResponseCorrect, nil)
 	defer teardown()
 
 	resource.Test(t, resource.TestCase{
@@ -70,10 +204,361 @@ func TestUnitPrimaryKeyResource(t *testing.T) {
 	})
 }
 
+// TestUnitPrimaryKeyDeserializationFix is the direct regression test for the
+// JSON tag bug. Before the fix, F5RespPrimaryKey used namespace-prefixed tags
+// ("f5-primary-key:hash", "f5-primary-key:status", "f5-primary-key:state") on
+// nested fields. The actual API response uses bare keys ("hash", "status",
+// "state"), so json.Unmarshal silently skipped them, leaving hash and status
+// as empty strings in Terraform state.
+//
+// This test verifies that Create correctly populates hash and status from the
+// API response with correct bare-key tags, and that the Terraform state reflects
+// both values rather than nulls.
+func TestUnitPrimaryKeyDeserializationFix(t *testing.T) {
+	withFastPolling(t)
+	setupPrimaryKeyMock(t, primaryKeyResponseCorrect, nil)
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryKeyResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// These assertions would fail before the fix because
+					// hash and status would both be null/empty.
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "abc123hash"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyOldTagsProduceEmpty documents the compounded effect of the
+// broken pre-fix response format (namespace-prefixed nested keys) combined with
+// the async migration wait. With the old format, json.Unmarshal silently ignores
+// "f5-primary-key:state" / "f5-primary-key:hash" / "f5-primary-key:status",
+// leaving status as "" forever. waitForPrimaryKeyMigration never sees "COMPLETE"
+// and times out — Create fails rather than silently writing empty state.
+func TestUnitPrimaryKeyOldTagsProduceEmpty(t *testing.T) {
+	withFastPolling(t)
+	setupPrimaryKeyMock(t, primaryKeyResponseOldFormat, nil)
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryKeyResourceConfig,
+				// With the old response format status is never "COMPLETE", so
+				// waitForPrimaryKeyMigration times out and Create returns an error.
+				ExpectError: regexp.MustCompile(`primary key migration did not complete`),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyForceUpdateChange verifies that Update calls SetPrimaryKey
+// when force_update changes from false to true. This is the explicit re-key
+// signal: the user is asking to rotate the primary key.
+// Steps: Create (force_update=false, SetPrimaryKey called once) →
+//
+//	Update (force_update=true, SetPrimaryKey called a second time).
+func TestUnitPrimaryKeyForceUpdateChange(t *testing.T) {
+	withFastPolling(t)
+	var setCount int32
+	setupPrimaryKeyMock(t, primaryKeyResponseCorrect, &setCount)
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with force_update=false — SetPrimaryKey called once (Create always sets)
+			{
+				Config: testAccPrimaryKeyResourceNoForceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "false"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "abc123hash"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+				),
+			},
+			// Step 2: Update force_update=true — Update must call SetPrimaryKey again
+			{
+				Config: testAccPrimaryKeyResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "true"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "abc123hash"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+					func(s *terraform.State) error {
+						// Create (step 1) + Update with force_update=true (step 2) = 2 calls
+						if atomic.LoadInt32(&setCount) != 2 {
+							return fmt.Errorf("expected SetPrimaryKey called twice (Create + force Update), got %d", setCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyCreateAlwaysSets verifies that Create always calls
+// SetPrimaryKey regardless of force_update. Before the fix, Create with
+// force_update=false would skip SetPrimaryKey when a key already existed,
+// silently failing to apply new passphrase/salt on key rotation (after a
+// RequiresReplace destroy+recreate cycle).
+func TestUnitPrimaryKeyCreateAlwaysSets(t *testing.T) {
+	withFastPolling(t)
+	var setCount int32
+	setupPrimaryKeyMock(t, primaryKeyResponseCorrect, &setCount)
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryKeyResourceNoForceConfig, // force_update=false
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "false"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "abc123hash"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+					func(s *terraform.State) error {
+						// Create must always call SetPrimaryKey, even when force_update=false.
+						if atomic.LoadInt32(&setCount) != 1 {
+							return fmt.Errorf("expected exactly 1 SetPrimaryKey call from Create, got %d", setCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyUpdateSkipsSetWhenNoForce verifies that Update skips
+// SetPrimaryKey when force_update=false, and only refreshes state from the
+// device. This is the correct home for the force_update guard.
+func TestUnitPrimaryKeyUpdateSkipsSetWhenNoForce(t *testing.T) {
+	withFastPolling(t)
+	var setCount int32
+	setupPrimaryKeyMock(t, primaryKeyResponseCorrect, &setCount)
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with force_update=true — SetPrimaryKey called once
+			{
+				Config: testAccPrimaryKeyResourceConfig, // force_update=true
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "true"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "abc123hash"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+				),
+			},
+			// Step 2: Update force_update=false — Update must NOT call SetPrimaryKey
+			{
+				Config: testAccPrimaryKeyResourceNoForceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "force_update", "false"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "abc123hash"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+					func(s *terraform.State) error {
+						// Create (step 1) called SetPrimaryKey once.
+						// Update (step 2, force_update=false) must NOT add another call.
+						if atomic.LoadInt32(&setCount) != 1 {
+							return fmt.Errorf("expected SetPrimaryKey called exactly once (Create only), got %d", setCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyAsyncMigration verifies that Create waits for the async primary key
+// migration to complete before returning. The device returns IN_PROGRESS immediately,
+// but the migration takes several seconds to complete. The test simulates this by having
+// the mock server return IN_PROGRESS for first few calls, then COMPLETE.
+func TestUnitPrimaryKeyAsyncMigration(t *testing.T) {
+	withFastPolling(t)
+	testAccPreUnitCheck(t)
+
+	var callCount int32
+
+	// GET primary-key state - return IN_PROGRESS on first 2 calls, then COMPLETE
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("unexpected HTTP method on primary-key endpoint: %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		count := atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusOK)
+		if count <= 2 {
+			// First two GETs (polls during wait) return IN_PROGRESS
+			_, _ = w.Write([]byte(`{
+				"f5-primary-key:primary-key": {
+					"state": {
+						"hash":   "",
+						"status": "IN_PROGRESS"
+					}
+				}
+			}`))
+		} else {
+			// Subsequent GETs return COMPLETE with hash
+			_, _ = w.Write([]byte(`{
+				"f5-primary-key:primary-key": {
+					"state": {
+						"hash":   "migrated-hash-value",
+						"status": "COMPLETE"
+					}
+				}
+			}`))
+		}
+	})
+
+	// POST SetPrimaryKey
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key/f5-primary-key:set", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("unexpected HTTP method on set endpoint: %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryKeyResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "id", "primary-key"),
+					// After migration completes, state should have the final hash
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "hash", "migrated-hash-value"),
+					resource.TestCheckResourceAttr("f5os_primarykey.default", "status", "COMPLETE"),
+					// Verify polling happened: callCount should be > 2 (SetPrimaryKey returns immediately,
+					// then polling calls GetPrimaryKey multiple times)
+					func(s *terraform.State) error {
+						if atomic.LoadInt32(&callCount) <= 2 {
+							return fmt.Errorf("expected multiple polling calls, got only %d", callCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitPrimaryKeyMigrationTimeout verifies that if the migration never completes,
+// Create fails with a timeout error. This test sets up the mock to always return
+// IN_PROGRESS to simulate a stuck migration.
+func TestUnitPrimaryKeyMigrationTimeout(t *testing.T) {
+	withFastPolling(t)
+	testAccPreUnitCheck(t)
+
+	// GET primary-key state - always return IN_PROGRESS (migration never completes)
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"f5-primary-key:primary-key": {
+				"state": {
+					"hash":   "",
+					"status": "IN_PROGRESS"
+				}
+			}
+		}`))
+	})
+
+	// POST SetPrimaryKey
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa/f5-primary-key:primary-key/f5-primary-key:set", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPrimaryKeyResourceConfig,
+				ExpectError: regexp.MustCompile(`primary key migration did not complete`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// JSON deserialization unit test (pure Go, no Terraform framework)
+// ---------------------------------------------------------------------------
+
+// TestUnitPrimaryKeyJSONDeserialization directly validates the struct
+// deserialization fix without going through the Terraform test framework.
+// It unmarshals both the correct and old-format API responses and asserts
+// the resulting struct fields.
+func TestUnitPrimaryKeyJSONDeserialization(t *testing.T) {
+	t.Run("correct_tags_populate_fields", func(t *testing.T) {
+		var resp f5ossdk.F5RespPrimaryKey
+		if err := json.Unmarshal([]byte(primaryKeyResponseCorrect), &resp); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+		if resp.PrimaryKey.State.Hash != "abc123hash" {
+			t.Errorf("expected Hash=%q, got %q", "abc123hash", resp.PrimaryKey.State.Hash)
+		}
+		if resp.PrimaryKey.State.Status != "COMPLETE" {
+			t.Errorf("expected Status=%q, got %q", "COMPLETE", resp.PrimaryKey.State.Status)
+		}
+	})
+
+	t.Run("old_prefixed_tags_produce_empty", func(t *testing.T) {
+		var resp f5ossdk.F5RespPrimaryKey
+		if err := json.Unmarshal([]byte(primaryKeyResponseOldFormat), &resp); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+		if resp.PrimaryKey.State.Hash != "" {
+			t.Errorf("expected empty Hash with old tag format, got %q", resp.PrimaryKey.State.Hash)
+		}
+		if resp.PrimaryKey.State.Status != "" {
+			t.Errorf("expected empty Status with old tag format, got %q", resp.PrimaryKey.State.Status)
+		}
+	})
+}
+
 const testAccPrimaryKeyResourceConfig = `
 resource "f5os_primarykey" "default" {
   passphrase   = "test-pass"
   salt         = "test-salt"
   force_update = true
+}
+`
+
+const testAccPrimaryKeyResourceNoForceConfig = `
+resource "f5os_primarykey" "default" {
+  passphrase   = "test-pass"
+  salt         = "test-salt"
+  force_update = false
 }
 `

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,13 +1,16 @@
 package provider
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
 
 const (
@@ -26,6 +29,10 @@ var (
 
 	// server is a test HTTP server used to provide mock API responses
 	server *httptest.Server
+
+	// savedEnv holds the original F5OS env vars so teardown() can restore
+	// them after unit tests that overwrite them with mock-server values.
+	savedEnv map[string]string
 )
 
 var (
@@ -51,14 +58,22 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func testAccPreUnitCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
+	// Save original env vars so teardown() can restore them. This prevents
+	// unit tests from polluting F5OS_HOST for acceptance tests that run
+	// later in the same process.
+	savedEnv = map[string]string{
+		"F5OS_HOST":          os.Getenv("F5OS_HOST"),
+		"F5OS_USERNAME":      os.Getenv("F5OS_USERNAME"),
+		"F5OS_PASSWORD":      os.Getenv("F5OS_PASSWORD"),
+		"F5OS_POLL_INTERVAL": os.Getenv("F5OS_POLL_INTERVAL"),
+	}
 	setup()
 	_ = os.Setenv("F5OS_HOST", server.URL)
 	_ = os.Setenv("F5OS_USERNAME", "testuser")
 	_ = os.Setenv("F5OS_PASSWORD", "testpass")
-	//defer teardown()
+	// Use a very short poll interval in unit tests to avoid the 20-second
+	// sleeps that the real client uses between polling iterations.
+	_ = os.Setenv("F5OS_POLL_INTERVAL", "1ms")
 }
 
 func setup() {
@@ -69,6 +84,18 @@ func setup() {
 
 func teardown() {
 	server.Close()
+	// Restore original env vars so acceptance tests that run later in the
+	// same process connect to the real device, not the (now-closed) mock.
+	if savedEnv != nil {
+		for k, v := range savedEnv {
+			if v == "" {
+				_ = os.Unsetenv(k)
+			} else {
+				_ = os.Setenv(k, v)
+			}
+		}
+		savedEnv = nil
+	}
 }
 
 // loadFixtureBytes returns the entire contents of the given file as a byte slice
@@ -83,4 +110,60 @@ func loadFixtureBytes(path string) []byte {
 // loadFixtureString returns the entire contents of the given file as a string
 func loadFixtureString(path string) string {
 	return string(loadFixtureBytes(path))
+}
+
+// testAccPreCheckPlatformRSeries creates a throwaway f5osclient session to
+// detect the device's platform type and skips the test if it is not rSeries.
+// Use this in PreCheck for acceptance tests that assume an rSeries target.
+func testAccPreCheckPlatformRSeries(t *testing.T) {
+	t.Helper()
+	testAccPreCheck(t)
+
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	client, err := f5ossdk.NewSession(&f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("testAccPreCheckPlatformRSeries: failed to create session: %s", err)
+	}
+	// PlatformType for rSeries is the model name (e.g. "r5900", "r12800-DS").
+	// Skip if the device is a VELOS partition or controller.
+	if client.PlatformType == "Velos Partition" || client.PlatformType == "Velos Controller" {
+		t.Skipf("skipping: test requires rSeries but device is %q", client.PlatformType)
+	}
+}
+
+// setupMockPlatformVersion registers handlers on the shared mux that make
+// NewSession detect an rSeries platform running the specified F5OS version.
+// Call this after testAccPreUnitCheck(t) and before registering test-specific
+// handlers. Any mocked test that needs version-gated behavior (e.g., v1.7+
+// password policy fields, v1.8+ TLS SAN) should use this helper.
+func setupMockPlatformVersion(m *http.ServeMux, version string) {
+	// Handler 1: Return an rSeries platform component list so
+	// setPlatformType() detects "rSeries Platform" and calls setPlatformVersion().
+	m.HandleFunc("/restconf/data/openconfig-platform:components/component", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_components_rseries.json"))
+	})
+
+	// Handler 2: Return the specified version so setPlatformVersion() sets
+	// client.PlatformVersion to the value we want.
+	m.HandleFunc("/restconf/data/openconfig-system:system/f5-system-image:image/state/install", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"f5-system-image:install":{"install-os-version":"%s","install-status":"success"}}`, version)
+	})
 }

--- a/internal/provider/proxy_acc_test.go
+++ b/internal/provider/proxy_acc_test.go
@@ -51,7 +51,7 @@ func testAccProxyPreCheck(t *testing.T) {
 	// Check standard F5OS env vars
 	for _, envVar := range []string{"F5OS_HOST", "F5OS_USERNAME", "F5OS_PASSWORD"} {
 		if os.Getenv(envVar) == "" {
-			t.Fatalf("%s must be set for proxy acceptance tests", envVar)
+			t.Skipf("%s must be set for proxy acceptance tests", envVar)
 		}
 	}
 

--- a/internal/provider/proxy_unit_test.go
+++ b/internal/provider/proxy_unit_test.go
@@ -259,9 +259,9 @@ func TestTransportProxy_CustomProxyFuncRoutes(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		w.WriteHeader(resp.StatusCode)
-		fmt.Fprint(w, "proxied")
+		_, _ = fmt.Fprint(w, "proxied")
 	}))
 	defer proxy.Close()
 
@@ -275,7 +275,7 @@ func TestTransportProxy_CustomProxyFuncRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET through proxy failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if proxyHitCount == 0 {
 		t.Fatal("expected request to hit the proxy, but it did not")
@@ -329,7 +329,7 @@ func TestTransportProxy_SelectiveProxyByHost(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		w.WriteHeader(resp.StatusCode)
 	}))
 	defer proxy.Close()
@@ -378,7 +378,7 @@ func TestTransportProxy_ReusedAfterNewSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET with session Transport failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)

--- a/internal/provider/tenant_image_data_source.go
+++ b/internal/provider/tenant_image_data_source.go
@@ -93,7 +93,7 @@ func (d *ImageInfoDataSource) Read(ctx context.Context, req datasource.ReadReque
 				if val.Status == "not-present" || val.Status == "processing" {
 					availableFlag = false
 				}
-				if val.Status == "replicated" || val.Status == "processed" {
+				if val.Status == "replicated" || val.Status == "processed" || val.Status == "verified" {
 					diff := time.Until(timeBefore)
 					if diff <= 2*time.Minute {
 						time.Sleep(2 * time.Minute)

--- a/internal/provider/tenant_image_data_source_test.go
+++ b/internal/provider/tenant_image_data_source_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -8,35 +10,63 @@ import (
 )
 
 func TestAccTenantImageDataSourceTC1Resource(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	// Ensure DNS is configured so hostname resolution works, but do NOT
+	// try to import the test image (the insecure field may be rejected
+	// on some F5OS versions). Instead, discover whatever image already
+	// exists on the device.
+	testAccPreCheck(t)
+	testAccEnsureDNSServer(t)
+
+	imageName := testAccGetExistingImageName(t)
+
+	// Pre-query the device to get the expected status for verification.
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create client: %v", err)
+	}
+	imgResp, err := client.GetImage(imageName)
+	if err != nil || imgResp == nil || len(imgResp.TenantImages) == 0 {
+		t.Skipf("Cannot query image %q: %v", imageName, err)
+	}
+	expectedStatus := imgResp.TenantImages[0].Status
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Read testing
+			// Step 1: Read an image that exists on the DUT.
 			{
-				Config: testAccTenantImageDatasourceConfig,
+				Config: testAccTenantImageDatasourceConfigDynamic(imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.f5os_tenant_image.test", "id", "BIG-IP-Next-20.0.1-2.123.17"),
+					resource.TestCheckResourceAttr("data.f5os_tenant_image.test", "id", imageName),
+					resource.TestCheckResourceAttr("data.f5os_tenant_image.test", "image_name", imageName),
+					resource.TestCheckResourceAttr("data.f5os_tenant_image.test", "image_status", expectedStatus),
 				),
 			},
+			// Step 2: Read an image that does NOT exist — expect an error.
+			// The data source returns "Unable to Get Image Details" when
+			// GetImage fails with a 404.
 			{
 				Config:      testAccTenantImageDatasourceFailConfig,
-				ExpectError: regexp.MustCompile("TF-001:Unable to Get Image Details"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.f5os_tenant_image.test", "id", "BIG-IP-Next-20.0.1-2.123.18"),
-				),
+				ExpectError: regexp.MustCompile(`Unable to Get Image Details`),
 			},
 		},
 	})
 }
 
-const testAccTenantImageDatasourceConfig = `
+func testAccTenantImageDatasourceConfigDynamic(imageName string) string {
+	return fmt.Sprintf(`
 data "f5os_tenant_image" "test" {
-  image_name             = "BIG-IP-Next-20.0.1-2.123.17"
+  image_name = %q
 }
-`
+`, imageName)
+}
+
 const testAccTenantImageDatasourceFailConfig = `
 data "f5os_tenant_image" "test" {
-  image_name             = "BIG-IP-Next-20.0.1-2.123.18"
+  image_name = "BIGIP-nonexistent-datasource-test.qcow2.zip.bundle"
 }
 `

--- a/internal/provider/tenant_image_resource.go
+++ b/internal/provider/tenant_image_resource.go
@@ -12,7 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -45,6 +48,7 @@ type TenantImageResourceModel struct {
 	RemotePassword types.String `tfsdk:"remote_password"`
 	RemotePath     types.String `tfsdk:"remote_path"`
 	RemotePort     types.Int64  `tfsdk:"remote_port"`
+	Insecure       types.Bool   `tfsdk:"insecure"`
 	Timeout        types.Int64  `tfsdk:"timeout"`
 	Id             types.String `tfsdk:"id"`
 	Status         types.String `tfsdk:"status"`
@@ -63,12 +67,18 @@ func (r *TenantImageResource) Schema(ctx context.Context, req resource.SchemaReq
 			"image_name": schema.StringAttribute{
 				MarkdownDescription: "Name of the tenant image.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"local_path": schema.StringAttribute{
 				MarkdownDescription: "The path on the F5OS where the the tenant image is to be imported to.",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"images/tenant", "images", "images/staging", "images/import/iso"}...),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"upload_from_path": schema.StringAttribute{
@@ -80,32 +90,71 @@ func (r *TenantImageResource) Schema(ctx context.Context, req resource.SchemaReq
 					stringvalidator.ConflictsWith(path.MatchRoot("remote_port")),
 					stringvalidator.ConflictsWith(path.MatchRoot("remote_user")),
 					stringvalidator.ConflictsWith(path.MatchRoot("remote_password")),
+					stringvalidator.ConflictsWith(path.MatchRoot("protocol")),
+					stringvalidator.ConflictsWith(path.MatchRoot("remote_path")),
+					stringvalidator.ConflictsWith(path.MatchRoot("insecure")),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"protocol": schema.StringAttribute{
-				MarkdownDescription: "Protocol for image transfer.",
+				MarkdownDescription: "Protocol for image transfer. Supported values: `scp`, `sftp`, `https`.",
 				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("scp", "sftp", "https"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"remote_host": schema.StringAttribute{
 				MarkdownDescription: "The hostname or IP address of the remote server on which the tenant image is stored.\nThe server must make the image accessible via the specified protocol.",
 				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"remote_user": schema.StringAttribute{
 				MarkdownDescription: "User name for the remote server on which the tenant image is stored.",
 				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"remote_password": schema.StringAttribute{
 				MarkdownDescription: "Password for the user on the remote server on which the tenant image is stored.",
 				Optional:            true,
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"remote_path": schema.StringAttribute{
 				MarkdownDescription: "The path to the tenant image on the remote server.",
 				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("upload_from_path")),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"remote_port": schema.Int64Attribute{
 				MarkdownDescription: "The port on the remote host to which you want to connect.\nIf the port is not provided, a default port for the selected protocol is used.",
 				Optional:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"insecure": schema.BoolAttribute{
+				MarkdownDescription: "When set to `true`, the image transfer skips TLS certificate verification on the remote host.\nUseful when importing images over HTTPS from servers with self-signed certificates.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"timeout": schema.Int64Attribute{
 				MarkdownDescription: "The number of seconds to wait for image import to finish.",
@@ -149,14 +198,12 @@ func (r *TenantImageResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	resp1Byte, _ := r.client.GetImage(data.ImageName.ValueString())
+	resp1Byte, getErr := r.client.GetImage(data.ImageName.ValueString())
+	if getErr != nil {
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Unable to check if image already exists, will attempt import: %s", getErr))
+	}
 
-	// if err != nil {
-	// 	resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to Import Image, got error: %s", err))
-	// 	return
-	// }
-
-	if resp1Byte == nil || len(resp1Byte.TenantImages) == 0 {
+	if getErr != nil || resp1Byte == nil || len(resp1Byte.TenantImages) == 0 {
 		if data.UploadFromPath.IsNull() {
 			respByte, err := r.importImage(ctx, data)
 			if err != nil {
@@ -212,11 +259,29 @@ func (r *TenantImageResource) importImage(ctx context.Context, data *TenantImage
 	timeout := int(data.Timeout.ValueInt64())
 	tflog.Info(ctx, fmt.Sprintf("timeout data :%+v", timeout))
 	importConfig := &f5ossdk.F5ReqTenantImage{}
-	importConfig.Insecure = ""
+	if data.Insecure.ValueBool() {
+		// The F5OS RESTCONF API models "insecure" as a YANG empty leaf.
+		// Per RFC 7951 the JSON encoding of an empty leaf is [null].
+		// When the field is nil it is omitted by omitempty (insecure disabled).
+		importConfig.Insecure = []interface{}{nil}
+	}
 	importConfig.RemoteHost = data.RemoteHost.ValueString()
 	importConfig.RemoteFile = fmt.Sprintf("%s/%s", data.RemotePath.ValueString(), data.ImageName.ValueString())
 	importConfig.LocalFile = data.LocalPath.ValueString()
-	tflog.Info(ctx, fmt.Sprintf("Create Data:%+v", importConfig))
+	if !data.Protocol.IsNull() && !data.Protocol.IsUnknown() {
+		importConfig.Protocol = data.Protocol.ValueString()
+	}
+	if !data.RemoteUser.IsNull() && !data.RemoteUser.IsUnknown() {
+		importConfig.Username = data.RemoteUser.ValueString()
+	}
+	if !data.RemotePassword.IsNull() && !data.RemotePassword.IsUnknown() {
+		importConfig.Password = data.RemotePassword.ValueString()
+	}
+	if !data.RemotePort.IsNull() && !data.RemotePort.IsUnknown() {
+		importConfig.RemotePort = int(data.RemotePort.ValueInt64())
+	}
+	tflog.Info(ctx, fmt.Sprintf("Create Data: RemoteHost=%s, RemoteFile=%s, LocalFile=%s, Protocol=%s, Username=%s, RemotePort=%d",
+		importConfig.RemoteHost, importConfig.RemoteFile, importConfig.LocalFile, importConfig.Protocol, importConfig.Username, importConfig.RemotePort))
 	return r.client.ImportImage(importConfig, timeout)
 }
 
@@ -227,7 +292,7 @@ func (r *TenantImageResource) uploadImage(ctx context.Context, data *TenantImage
 	imageName := data.ImageName.ValueString()
 	filePath := go_path.Join(imageDir, imageName)
 	tflog.Info(ctx, "Uploading image")
-	r.client.ConfigOptions.APICallTimeout = time.Duration(time.Duration(timeout).Seconds())
+	r.client.ConfigOptions.APICallTimeout = time.Duration(timeout) * time.Second
 	return r.client.UploadImage(filePath)
 }
 
@@ -298,11 +363,14 @@ func (r *TenantImageResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 func (r *TenantImageResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	// The import ID is the image name, which maps to both "id" and "image_name"
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("image_name"), req.ID)...)
 }
 
 func (r *TenantImageResource) tenantImageResourceModeltoState(ctx context.Context, respData *f5ossdk.F5RespTenantImagesStatus, data *TenantImageResourceModel) {
 	tflog.Info(ctx, fmt.Sprintf("respData :%+v", respData))
 	data.ImageName = types.StringValue(respData.TenantImages[0].Name)
 	data.Status = types.StringValue(respData.TenantImages[0].Status)
+	data.Id = types.StringValue(respData.TenantImages[0].Name)
 }

--- a/internal/provider/tenant_image_resource_test.go
+++ b/internal/provider/tenant_image_resource_test.go
@@ -1,24 +1,144 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
+
+// ---------------------------------------------------------------------------
+// Acceptance test constants
+// ---------------------------------------------------------------------------
+
+const (
+	// testAccDNSServer is the DNS server required to resolve hostnames from the DUT.
+	testAccDNSServer = "192.168.72.180"
+
+	// testAccImageName is the standard test image name used across acceptance tests.
+	testAccImageName = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+
+	// testAccImageRemoteHost is the image server accessible from the DUT.
+	testAccImageRemoteHost = "10.238.1.148"
+
+	// testAccImageRemotePath is the path on the image server where test images live.
+	testAccImageRemotePath = "v17.1.0.1/dist/release/VM"
+)
+
+// ---------------------------------------------------------------------------
+// Acceptance test setup helpers
+// ---------------------------------------------------------------------------
+
+// testAccEnsureDNSServer ensures the required DNS server is configured on the
+// DUT so that hostnames can be resolved. This is idempotent — it only adds
+// the server if it's not already present.
+func testAccEnsureDNSServer(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TF_ACC") == "" {
+		return // Only run during acceptance tests
+	}
+
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Logf("Warning: cannot create client to check DNS: %v", err)
+		return
+	}
+
+	// Read current DNS config
+	dnsConfig, err := client.ReadDNSConfig()
+	if err != nil {
+		// DNS config may not exist yet — that's OK, we'll create it
+		t.Logf("DNS config not present, will add DNS server %s", testAccDNSServer)
+	} else {
+		// Check if the DNS server is already present
+		for _, server := range dnsConfig.DNS.Servers.Server {
+			if server.Address == testAccDNSServer {
+				t.Logf("DNS server %s already configured", testAccDNSServer)
+				return
+			}
+		}
+	}
+
+	// Add the DNS server
+	t.Logf("Adding DNS server %s to DUT", testAccDNSServer)
+	err = client.PatchDNSConfig([]string{testAccDNSServer}, nil)
+	if err != nil {
+		t.Logf("Warning: failed to add DNS server %s: %v", testAccDNSServer, err)
+	}
+}
+
+// testAccEnsureTestImage ensures the standard test image exists on the DUT.
+// If the image is not present, it imports it from the image server.
+// This is idempotent — it only imports if the image doesn't exist.
+func testAccEnsureTestImage(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TF_ACC") == "" {
+		return // Only run during acceptance tests
+	}
+
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Fatalf("Cannot create client to check test image: %v", err)
+	}
+
+	// Check if the image already exists
+	resp, err := client.GetImage(testAccImageName)
+	if err == nil && resp != nil && len(resp.TenantImages) > 0 {
+		t.Logf("Test image %s already exists on device (status: %s)", testAccImageName, resp.TenantImages[0].Status)
+		return
+	}
+
+	// Image doesn't exist — import it
+	t.Logf("Importing test image %s from %s", testAccImageName, testAccImageRemoteHost)
+	importConfig := &f5ossdk.F5ReqTenantImage{
+		RemoteHost: testAccImageRemoteHost,
+		RemoteFile: fmt.Sprintf("%s/%s", testAccImageRemotePath, testAccImageName),
+		LocalFile:  "images/tenant",
+		Insecure:   []interface{}{nil}, // YANG empty leaf (RFC 7951): [null]
+	}
+
+	_, err = client.ImportImage(importConfig, 600) // 10 minute timeout for large images
+	if err != nil {
+		// Check if it's an "already exists" error (race condition with another test)
+		if strings.Contains(err.Error(), "already exists") {
+			t.Logf("Test image %s was imported by another process", testAccImageName)
+			return
+		}
+		t.Fatalf("Failed to import test image %s: %v", testAccImageName, err)
+	}
+	t.Logf("Successfully imported test image %s", testAccImageName)
+}
+
+// testAccPreCheckWithSetup combines testAccPreCheck with DNS and image setup.
+// Use this as the PreCheck for acceptance tests that need the test image.
+func testAccPreCheckWithSetup(t *testing.T) {
+	testAccPreCheck(t)
+	testAccEnsureDNSServer(t)
+	testAccEnsureTestImage(t)
+}
 
 func TestAccTenantImageCreateTC1Resource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
 				Config: testAccTenantImageCreateResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", testAccImageName),
+					testAccCheckTenantImageExistsOnDevice(testAccImageName),
 				),
 			},
 			// ImportState testing
@@ -26,6 +146,11 @@ func TestAccTenantImageCreateTC1Resource(t *testing.T) {
 				ResourceName:      "f5os_tenant_image.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
 			},
 		},
 	})
@@ -33,14 +158,16 @@ func TestAccTenantImageCreateTC1Resource(t *testing.T) {
 
 func TestAccTenantImageCreateTC2Resource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
 				Config: testAccTenantImageCreateTC2ResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", testAccImageName),
+					testAccCheckTenantImageExistsOnDevice(testAccImageName),
 				),
 			},
 			// ImportState testing
@@ -53,8 +180,9 @@ func TestAccTenantImageCreateTC2Resource(t *testing.T) {
 	})
 }
 
-func TestAccTenantImageCreateUnitTC3Resource(t *testing.T) {
+func TestUnitTenantImageCreateTC3Resource(t *testing.T) {
 	testAccPreUnitCheck(t)
+	defer teardown()
 	var count = 0
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
@@ -122,8 +250,9 @@ func TestAccTenantImageCreateUnitTC3Resource(t *testing.T) {
 	})
 }
 
-func TestAccTenantImageCreateUnitTC4Resource(t *testing.T) {
+func TestUnitTenantImageCreateTC4Resource(t *testing.T) {
 	testAccPreUnitCheck(t)
+	defer teardown()
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("Content-Type", "application/yang-data+json")
@@ -186,11 +315,538 @@ func TestAccTenantImageCreateUnitTC4Resource(t *testing.T) {
 			{
 				ResourceName:      "f5os_tenant_image.test",
 				ImportState:       true,
-				ImportStateVerify: false,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
 			},
 		},
 	})
 }
+
+// TestUnitTenantImageRequiresReplaceOnRemotePathChange verifies that changing
+// remote_path forces a destroy+recreate cycle (RequiresReplace plan modifier).
+// The test uses two steps: Step 1 creates the image, Step 2 changes remote_path
+// and verifies the resource is replaced (new import + delete of old).
+func TestUnitTenantImageRequiresReplaceOnRemotePathChange(t *testing.T) {
+	testAccPreUnitCheck(t)
+	var createCount int
+	var deleteCount int
+	imageExists := false
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if !imageExists {
+			// Image not present — return empty so Create triggers import
+			_, _ = fmt.Fprintf(w, "%s", "")
+		} else {
+			_, _ = fmt.Fprintf(w, "%s", `{"f5-tenant-images:image": [{
+            "name": "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "in-use": false,
+            "type": "vm-image",
+            "status": "replicated",
+            "date": "2023-3-27",
+            "size": "2.27 GB"}]}`)
+		}
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/import", func(w http.ResponseWriter, r *http.Request) {
+		createCount++
+		imageExists = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/transfer-operations/transfer-operation", func(w http.ResponseWriter, r *http.Request) {
+		// Return a dynamic transfer status that includes entries for both
+		// the original and replacement remote paths so importWait finds a match.
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{
+    "f5-utils-file-transfer:transfer-operation": [
+        {
+            "local-file-path": "images/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "remote-host": %q,
+            "remote-file-path": "v17.1.0.1/dist/release/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "operation": "Import file",
+            "protocol": "HTTPS   ",
+            "status": "         Completed",
+            "timestamp": "Mon Jun 26 16:05:22 2023"
+        },
+        {
+            "local-file-path": "images/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "remote-host": %q,
+            "remote-file-path": "v17.1.0.1/daily/previous/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "operation": "Import file",
+            "protocol": "HTTPS   ",
+            "status": "         Completed",
+            "timestamp": "Mon Jun 26 16:10:22 2023"
+        }
+    ]
+}`, testAccImageRemoteHost, testAccImageRemoteHost)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/remove", func(w http.ResponseWriter, r *http.Request) {
+		deleteCount++
+		imageExists = false
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", `{
+    "f5-tenant-images:output": {
+        "result": "Successful."
+    }
+}`)
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create image from the standard test remote_path
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_path", testAccImageRemotePath),
+				),
+			},
+			// Step 2: Change remote_path — RequiresReplace should trigger
+			// destroy + recreate, NOT an in-place update.
+			{
+				Config: testAccTenantImageRequiresReplaceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_path", "v17.1.0.1/daily/previous/VM"),
+					func(s *terraform.State) error {
+						// createCount should be 2: one for Step 1 + one for Step 2 re-create
+						if createCount < 2 {
+							return fmt.Errorf("expected at least 2 import calls (create+replace), got %d", createCount)
+						}
+						// deleteCount should be >= 1: at least the destroy from replacement
+						if deleteCount < 1 {
+							return fmt.Errorf("expected at least 1 delete call (replacement destroy), got %d", deleteCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageTimeoutChangeNoReplace verifies that changing only
+// timeout does NOT force a destroy+recreate — it's an in-place update.
+func TestUnitTenantImageTimeoutChangeNoReplace(t *testing.T) {
+	testAccPreUnitCheck(t)
+	var deleteCount int
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	var firstGet = true
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method == "GET" && firstGet {
+			_, _ = fmt.Fprintf(w, "%s", "")
+			firstGet = false
+		} else {
+			_, _ = fmt.Fprintf(w, "%s", `{"f5-tenant-images:image": [{
+            "name": "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "in-use": false,
+            "type": "vm-image",
+            "status": "replicated",
+            "date": "2023-3-27",
+            "size": "2.27 GB"}]}`)
+		}
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/import", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/transfer-operations/transfer-operation", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_image_transfer_status.json"))
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/remove", func(w http.ResponseWriter, r *http.Request) {
+		deleteCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", `{
+    "f5-tenant-images:output": {
+        "result": "Successful."
+    }
+}`)
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Change only timeout (360 -> 380) — no replacement
+			{
+				Config: testAccTenantImageCreateTC2ModifyResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					func(s *terraform.State) error {
+						// Between Step 1 and Step 2, no delete should occur
+						// (only the final destroy at test cleanup will delete).
+						if deleteCount > 0 {
+							return fmt.Errorf("timeout change should not trigger delete, but got %d deletes", deleteCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test helpers
+// ---------------------------------------------------------------------------
+
+// newTenantImageClientFromEnv creates a fresh f5osclient session from env vars.
+// Port defaults to 8888 to match the provider.
+func newTenantImageClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
+
+// testAccCheckTenantImageExistsOnDevice queries the device directly and verifies
+// the named image is present (any status).
+func testAccCheckTenantImageExistsOnDevice(imageName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newTenantImageClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		resp, err := client.GetImage(imageName)
+		if err != nil {
+			return fmt.Errorf("GetImage(%q) failed: %w", imageName, err)
+		}
+		if resp == nil || len(resp.TenantImages) == 0 {
+			return fmt.Errorf("image %q not found on device", imageName)
+		}
+		return nil
+	}
+}
+
+// testAccCheckTenantImageDestroy verifies the image is gone from the device.
+// It tolerates images that are still present but in-use by tenants, since
+// the F5OS API refuses to delete in-use images and the test framework
+// always runs a final destroy.
+func testAccCheckTenantImageDestroy(s *terraform.State) error {
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		return nil // cannot connect — treat as destroyed
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "f5os_tenant_image" {
+			continue
+		}
+		imageName := rs.Primary.Attributes["image_name"]
+		resp, err := client.GetImage(imageName)
+		if err != nil {
+			continue // not found — ok
+		}
+		if resp != nil && len(resp.TenantImages) > 0 {
+			// If the image is in-use, the API refuses to delete it.
+			// This is expected on shared test devices — tolerate it.
+			if resp.TenantImages[0].InUse {
+				continue
+			}
+			return fmt.Errorf("image %q still exists on device after destroy", imageName)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests
+// ---------------------------------------------------------------------------
+
+// TestAccTenantImageRequiresReplace verifies that changing remote_path
+// (a RequiresReplace attribute) causes Terraform to attempt destroy+recreate.
+//
+// Step 1 creates the resource (adopts an existing image on the device).
+// Step 2 changes remote_path which triggers RequiresReplace. The image is
+// in-use by existing tenants so the destroy fails, but the error itself
+// proves that Terraform executed a replace plan (destroy was attempted before
+// re-create). Without RequiresReplace, no destroy would be attempted at all.
+//
+// NOTE: The post-test destroy will fail on shared DUTs where the image is
+// in-use by other tenants. Set F5OS_TENANT_IMAGE_ACC_TEST_IMAGE to a
+// not-in-use image name if the test fails due to post-test cleanup.
+func TestAccTenantImageRequiresReplace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create — adopts the pre-existing image.
+			// GetImage finds it already present, so no import is triggered.
+			{
+				Config: testAccTenantImageReplaceConfig("v17.1.0.1/daily/current/VM"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.replace_test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.replace_test", "remote_path", "v17.1.0.1/daily/current/VM"),
+					testAccCheckTenantImageExistsOnDevice("BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Change remote_path — RequiresReplace must generate a
+			// non-empty plan (destroy+recreate). PlanOnly verifies the plan
+			// is non-empty without applying, avoiding post-test destroy
+			// issues on shared DUTs. Unit tests separately verify the exact
+			// DestroyBeforeCreate action type.
+			{
+				Config:             testAccTenantImageReplaceConfig("v17.1.0.1/daily/release/VM"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccTenantImageTimeoutNoReplace verifies that changing timeout does NOT
+// trigger destroy+recreate — it is an in-place update (Update method is called).
+// Uses an in-use image that is already on the device. The post-test destroy
+// will fail because the image is in-use, but CheckDestroy tolerates this.
+func TestAccTenantImageTimeoutNoReplace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with timeout=360. Image already exists on device
+			// so Create skips the import.
+			{
+				Config: testAccTenantImageAccTimeoutConfig(360),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.acc_test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.acc_test", "timeout", "360"),
+					testAccCheckTenantImageExistsOnDevice("BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Change timeout to 600 — must be an in-place update,
+			// not a destroy+recreate. The image must still exist on the device.
+			{
+				Config: testAccTenantImageAccTimeoutConfig(600),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.acc_test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.acc_test", "timeout", "600"),
+					testAccCheckTenantImageExistsOnDevice("BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccTenantImageRequiresReplaceOnProtocolChange verifies that changing
+// protocol (a RequiresReplace attribute) causes Terraform to attempt
+// destroy+recreate against a real device.
+//
+// Step 1 adopts the pre-existing in-use image with no protocol set (defaults).
+// Step 2 adds protocol="scp" which triggers RequiresReplace. The destroy
+// fails because the image is in-use, but the error itself proves Terraform
+// executed a replace plan.
+func TestAccTenantImageRequiresReplaceOnProtocolChange(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create — adopts the existing image (no protocol).
+			{
+				Config: testAccTenantImageAccFieldConfig("", 0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.field_test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					testAccCheckTenantImageExistsOnDevice("BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Add protocol="scp" — RequiresReplace must generate a
+			// non-empty plan. PlanOnly verifies without applying.
+			{
+				Config:             testAccTenantImageAccFieldConfig("scp", 0),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccTenantImageRequiresReplaceOnRemotePortChange verifies that changing
+// remote_port (a RequiresReplace attribute) causes Terraform to attempt
+// destroy+recreate against a real device.
+//
+// Step 1 adopts the pre-existing in-use image with no remote_port set.
+// Step 2 adds remote_port=2222 which triggers RequiresReplace.
+func TestAccTenantImageRequiresReplaceOnRemotePortChange(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create — adopts the existing image (no port).
+			{
+				Config: testAccTenantImageAccFieldConfig("", 0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.field_test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					testAccCheckTenantImageExistsOnDevice("BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Add remote_port=2222 — RequiresReplace must generate a
+			// non-empty plan. PlanOnly verifies without applying.
+			{
+				Config:             testAccTenantImageAccFieldConfig("", 2222),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccTenantImageNewFieldsCreateAndVerify verifies that a config using
+// all four newly-wired fields (protocol, remote_user, remote_password,
+// remote_port) is accepted by the provider and the image is present on
+// the device afterward. Since the image already exists on the device,
+// Create adopts it without performing a new import, so this test
+// validates schema acceptance rather than wire-level delivery. The
+// wire-level payload content is verified by the unit test
+// TestUnitTenantImageImportPayloadIncludesAllFields.
+func TestAccTenantImageNewFieldsCreateAndVerify(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageAccAllFieldsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.all_fields_test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.all_fields_test", "protocol", "https"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.all_fields_test", "remote_user", "imageuser"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.all_fields_test", "remote_password", "imagepass"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.all_fields_test", "remote_port", "8443"),
+					testAccCheckTenantImageExistsOnDevice("BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test HCL config functions
+// ---------------------------------------------------------------------------
+
+func testAccTenantImageReplaceConfig(remotePath string) string {
+	return fmt.Sprintf(`
+resource "f5os_tenant_image" "replace_test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageName, testAccImageRemoteHost, remotePath)
+}
+
+func testAccTenantImageAccTimeoutConfig(timeout int) string {
+	return fmt.Sprintf(`
+resource "f5os_tenant_image" "acc_test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = %d
+}
+`, testAccImageName, testAccImageRemoteHost, testAccImageRemotePath, timeout)
+}
+
+// testAccTenantImageAccFieldConfig generates an HCL config for testing
+// RequiresReplace on protocol and remote_port. Pass empty string / 0
+// to omit each optional attribute. Always includes insecure=true since
+// certificates are not functional on DUTs.
+func testAccTenantImageAccFieldConfig(protocol string, remotePort int) string {
+	var extra string
+	if protocol != "" {
+		extra += fmt.Sprintf("  protocol    = %q\n", protocol)
+	}
+	if remotePort != 0 {
+		extra += fmt.Sprintf("  remote_port = %d\n", remotePort)
+	}
+	return fmt.Sprintf(`
+resource "f5os_tenant_image" "field_test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = 360
+%s}
+`, testAccImageName, testAccImageRemoteHost, testAccImageRemotePath, extra)
+}
+
+// testAccTenantImageAccAllFieldsConfig exercises all four newly-wired
+// attributes (protocol, remote_user, remote_password, remote_port) against
+// a real device.
+var testAccTenantImageAccAllFieldsConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "all_fields_test" {
+  image_name      = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = %q
+  remote_path     = "v17.1.0.1/daily/current/VM"
+  local_path      = "images/tenant"
+  protocol        = "https"
+  remote_user     = "imageuser"
+  remote_password = "imagepass"
+  remote_port     = 8443
+  insecure        = true
+  timeout         = 360
+}
+`, testAccImageRemoteHost)
 
 //func TestUnitTenantImageUpload(t *testing.T) {
 //	testAccPreUnitCheck(t)
@@ -279,32 +935,1670 @@ func TestAccTenantImageCreateUnitTC4Resource(t *testing.T) {
 //	})
 //}
 
-const testAccTenantImageCreateResourceConfig = `
+// testAccTenantImageCreateResourceConfig uses the working image server and insecure=true
+// since certificates are not functional on DUTs.
+var testAccTenantImageCreateResourceConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageName, testAccImageRemoteHost, testAccImageRemotePath)
+
+// testAccTenantImageCreateTC2ResourceConfig uses local_path="images" (different
+// from TC1's "images/tenant") to exercise both valid local_path values.
+var testAccTenantImageCreateTC2ResourceConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images"
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageName, testAccImageRemoteHost, testAccImageRemotePath)
+
+// testAccTenantImageCreateTC2ModifyResourceConfig - modified timeout for update test
+var testAccTenantImageCreateTC2ModifyResourceConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images"
+  insecure    = true
+  timeout     = 380
+}
+`, testAccImageName, testAccImageRemoteHost, testAccImageRemotePath)
+
+// testAccTenantImageNoInsecureConfig is used by unit tests that verify the
+// default behavior when insecure is NOT set in the HCL config. This must NOT
+// include insecure=true (unlike the acceptance test configs which always set it).
+var testAccTenantImageNoInsecureConfig = fmt.Sprintf(`
 resource "f5os_tenant_image" "test" {
   image_name  = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
-  remote_host = "spkapexsrvc01.olympus.f5net.com"
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images"
+  timeout     = 360
+}
+`, testAccImageRemoteHost)
+
+// TestUnitTenantImageImportPayloadIncludesAllFields verifies that when protocol,
+// remote_user, remote_password, and remote_port are set in the HCL config, all
+// four values are included in the JSON body POSTed to the file-transfer import
+// endpoint. Before this fix, these fields were accepted by the schema but
+// silently discarded.
+func TestUnitTenantImageImportPayloadIncludesAllFields(t *testing.T) {
+	testAccPreUnitCheck(t)
+	var capturedBody map[string]interface{}
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	var firstGet = true
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method == "GET" && firstGet {
+			_, _ = fmt.Fprintf(w, "%s", "")
+			firstGet = false
+		} else {
+			_, _ = fmt.Fprintf(w, "%s", `{"f5-tenant-images:image": [{
+            "name": "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "in-use": false,
+            "type": "vm-image",
+            "status": "replicated",
+            "date": "2023-3-27",
+            "size": "2.27 GB"}]}`)
+		}
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/import", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/transfer-operations/transfer-operation", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_image_transfer_status.json"))
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/remove", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", `{
+    "f5-tenant-images:output": {
+        "result": "Successful."
+    }
+}`)
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageAllFieldsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "protocol", "scp"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_user", "admin"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_password", "secret123"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_port", "2222"),
+					func(s *terraform.State) error {
+						if capturedBody == nil {
+							return fmt.Errorf("import endpoint was never called")
+						}
+						if v, ok := capturedBody["protocol"]; !ok || v != "scp" {
+							return fmt.Errorf("expected protocol=scp in request body, got %v", v)
+						}
+						if v, ok := capturedBody["username"]; !ok || v != "admin" {
+							return fmt.Errorf("expected username=admin in request body, got %v", v)
+						}
+						if v, ok := capturedBody["password"]; !ok || v != "secret123" {
+							return fmt.Errorf("expected password=secret123 in request body, got %v", v)
+						}
+						// JSON numbers decode as float64
+						if v, ok := capturedBody["remote-port"]; !ok || v != float64(2222) {
+							return fmt.Errorf("expected remote-port=2222 in request body, got %v", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// testAccTenantImageAllFieldsConfig exercises all four previously-ignored
+// import attributes: protocol, remote_user, remote_password, remote_port.
+var testAccTenantImageAllFieldsConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name      = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = %q
+  remote_path     = "v17.1.0.1/daily/current/VM"
+  local_path      = "images"
+  protocol        = "scp"
+  remote_user     = "admin"
+  remote_password = "secret123"
+  remote_port     = 2222
+  timeout         = 360
+}
+`, testAccImageRemoteHost)
+
+// ---------------------------------------------------------------------------
+// Shared mock-server setup for RequiresReplace / payload unit tests
+// ---------------------------------------------------------------------------
+
+// tenantImageMockState holds mutable mock-server state shared across handlers.
+type tenantImageMockState struct {
+	createCount  int
+	deleteCount  int
+	imageExists  bool
+	capturedBody map[string]interface{}
+}
+
+// setupTenantImageMock registers all the standard mock handlers needed for
+// tenant_image unit tests and returns a pointer to the shared state so the
+// test can inspect call counts and captured payloads. The caller is
+// responsible for calling teardown() when the test completes.
+//
+// transferPaths lists the remote-file-path values that the transfer-status
+// endpoint should report as Completed. This lets multi-step tests that change
+// remote_path (or other attributes that alter the remote file) see a matching
+// transfer entry in each step.
+func setupTenantImageMock(t *testing.T, transferPaths []string) *tenantImageMockState {
+	t.Helper()
+	testAccPreUnitCheck(t)
+
+	st := &tenantImageMockState{}
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if !st.imageExists {
+			_, _ = fmt.Fprintf(w, "%s", "")
+		} else {
+			_, _ = fmt.Fprintf(w, "%s", `{"f5-tenant-images:image": [{
+            "name": "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+            "in-use": false,
+            "type": "vm-image",
+            "status": "replicated",
+            "date": "2023-3-27",
+            "size": "2.27 GB"}]}`)
+		}
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/import", func(w http.ResponseWriter, r *http.Request) {
+		st.createCount++
+		st.imageExists = true
+		body, _ := io.ReadAll(r.Body)
+		st.capturedBody = make(map[string]interface{})
+		_ = json.Unmarshal(body, &st.capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+
+	// Build transfer-status JSON with one Completed entry per path.
+	type transferEntry struct {
+		LocalFilePath  string `json:"local-file-path"`
+		RemoteHost     string `json:"remote-host"`
+		RemoteFilePath string `json:"remote-file-path"`
+		Operation      string `json:"operation"`
+		Protocol       string `json:"protocol"`
+		Status         string `json:"status"`
+		Timestamp      string `json:"timestamp"`
+	}
+	entries := make([]transferEntry, 0, len(transferPaths))
+	for _, p := range transferPaths {
+		entries = append(entries, transferEntry{
+			LocalFilePath:  "images/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+			RemoteHost:     testAccImageRemoteHost,
+			RemoteFilePath: p,
+			Operation:      "Import file",
+			Protocol:       "HTTPS   ",
+			Status:         "         Completed",
+			Timestamp:      "Mon Jun 26 16:05:22 2023",
+		})
+	}
+	type transferStatus struct {
+		Ops []transferEntry `json:"f5-utils-file-transfer:transfer-operation"`
+	}
+	tsBytes, _ := json.Marshal(transferStatus{Ops: entries})
+
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/transfer-operations/transfer-operation", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tsBytes)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/remove", func(w http.ResponseWriter, r *http.Request) {
+		st.deleteCount++
+		st.imageExists = false
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", `{
+    "f5-tenant-images:output": {
+        "result": "Successful."
+    }
+}`)
+	})
+
+	return st
+}
+
+// ---------------------------------------------------------------------------
+// RequiresReplace unit tests for each newly-wired attribute
+// ---------------------------------------------------------------------------
+
+// TestUnitTenantImageRequiresReplaceOnProtocolChange verifies that changing
+// protocol triggers destroy+recreate (RequiresReplace).
+func TestUnitTenantImageRequiresReplaceOnProtocolChange(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageAllFieldsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "protocol", "scp"),
+				),
+			},
+			{
+				Config: testAccTenantImageProtocolChangedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "protocol", "https"),
+					func(s *terraform.State) error {
+						if st.createCount < 2 {
+							return fmt.Errorf("expected >=2 import calls (create+replace), got %d", st.createCount)
+						}
+						if st.deleteCount < 1 {
+							return fmt.Errorf("expected >=1 delete call (replacement destroy), got %d", st.deleteCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageRequiresReplaceOnRemotePortChange verifies that changing
+// remote_port triggers destroy+recreate (RequiresReplace).
+func TestUnitTenantImageRequiresReplaceOnRemotePortChange(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageAllFieldsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_port", "2222"),
+				),
+			},
+			{
+				Config: testAccTenantImageRemotePortChangedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_port", "3333"),
+					func(s *terraform.State) error {
+						if st.createCount < 2 {
+							return fmt.Errorf("expected >=2 import calls (create+replace), got %d", st.createCount)
+						}
+						if st.deleteCount < 1 {
+							return fmt.Errorf("expected >=1 delete call (replacement destroy), got %d", st.deleteCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageRequiresReplaceOnRemoteUserChange verifies that changing
+// remote_user triggers destroy+recreate (RequiresReplace).
+func TestUnitTenantImageRequiresReplaceOnRemoteUserChange(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageAllFieldsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_user", "admin"),
+				),
+			},
+			{
+				Config: testAccTenantImageRemoteUserChangedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_user", "operator"),
+					func(s *terraform.State) error {
+						if st.createCount < 2 {
+							return fmt.Errorf("expected >=2 import calls (create+replace), got %d", st.createCount)
+						}
+						if st.deleteCount < 1 {
+							return fmt.Errorf("expected >=1 delete call (replacement destroy), got %d", st.deleteCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageRequiresReplaceOnRemoteHostChange verifies that changing
+// remote_host triggers destroy+recreate (RequiresReplace).
+func TestUnitTenantImageRequiresReplaceOnRemoteHostChange(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageAllFieldsConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_host", testAccImageRemoteHost),
+				),
+			},
+			{
+				Config: testAccTenantImageRemoteHostChangedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "remote_host", "mirror.olympus.f5net.com"),
+					func(s *terraform.State) error {
+						if st.createCount < 2 {
+							return fmt.Errorf("expected >=2 import calls (create+replace), got %d", st.createCount)
+						}
+						if st.deleteCount < 1 {
+							return fmt.Errorf("expected >=1 delete call (replacement destroy), got %d", st.deleteCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageOmitsOptionalFieldsWhenUnset verifies that when the
+// optional attributes (protocol, remote_user, remote_password, remote_port)
+// are not set in the HCL config, they are omitted from the JSON payload sent
+// to the import API (omitempty).
+func TestUnitTenantImageOmitsOptionalFieldsWhenUnset(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		fmt.Sprintf("%s/%s", testAccImageRemotePath, testAccImageName),
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					func(s *terraform.State) error {
+						if st.capturedBody == nil {
+							return fmt.Errorf("import endpoint was never called")
+						}
+						for _, key := range []string{"protocol", "username", "password", "remote-port"} {
+							if v, ok := st.capturedBody[key]; ok {
+								// remote-port may be 0 (Go int zero value) — treat that as omitted
+								if f, isFloat := v.(float64); isFloat && f == 0 {
+									continue
+								}
+								return fmt.Errorf("expected %q to be absent from request body, but got %v", key, v)
+							}
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageImportSetsImageName verifies that ImportState populates
+// both "id" and "image_name" in state, and that the subsequent Read fills in
+// "status". Before the fix, ImportState only set "id", causing Read to write
+// state with a null image_name — losing the Required attribute.
+func TestUnitTenantImageImportSetsImageName(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		fmt.Sprintf("%s/%s", testAccImageRemotePath, testAccImageName),
+	})
+	_ = st
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the resource so there is something to import
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "image_name", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Import and verify that id, image_name, and status
+			// survive the round-trip. Transfer config attributes are
+			// legitimately lost (the API does not store them).
+			{
+				ResourceName:      "f5os_tenant_image.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageUpdatePreservesIdAndImageName verifies that after an
+// in-place Update (e.g. timeout change), the state still contains the correct
+// "id" and "image_name". Before the tenantImageResourceModeltoState fix,
+// the helper did not set data.Id, so the Id written to state during Update
+// depended solely on whatever the plan carried forward. This test confirms
+// the fix works by asserting both fields survive a two-step create→update.
+func TestUnitTenantImageUpdatePreservesIdAndImageName(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		fmt.Sprintf("%s/%s", testAccImageRemotePath, testAccImageName),
+	})
+	_ = st
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "image_name", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "status", "replicated"),
+				),
+			},
+			// Step 2: Change timeout (in-place update) — id, image_name,
+			// and status must all survive the Update path.
+			{
+				Config: testAccTenantImageCreateTC2ModifyResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "image_name", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "status", "replicated"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageStatusPopulatedAfterCreate verifies that the "status"
+// attribute is populated from the API response after Create. The
+// tenantImageResourceModeltoState helper is responsible for mapping the
+// API's "status" field into the Terraform state.
+func TestUnitTenantImageStatusPopulatedAfterCreate(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		fmt.Sprintf("%s/%s", testAccImageRemotePath, testAccImageName),
+	})
+	_ = st
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "status", "replicated"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageInsecureFlagInPayload verifies that when insecure=true
+// is set in the HCL config, the import payload includes the "insecure" key
+// encoded as [null] (RFC 7951 YANG empty leaf). When insecure is false (the
+// default), the field should be omitted from the payload entirely.
+func TestUnitTenantImageInsecureFlagInPayload(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageInsecureTrueConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "insecure", "true"),
+					func(s *terraform.State) error {
+						if st.capturedBody == nil {
+							return fmt.Errorf("import endpoint was never called")
+						}
+						// The F5OS API models "insecure" as a YANG empty leaf.
+						// Per RFC 7951 the JSON encoding is [null].
+						v, ok := st.capturedBody["insecure"]
+						if !ok {
+							return fmt.Errorf("expected insecure key present in request body, but it was absent")
+						}
+						// json.Unmarshal decodes [null] as []interface{}{nil}.
+						arr, isArr := v.([]interface{})
+						if !isArr || len(arr) != 1 || arr[0] != nil {
+							return fmt.Errorf("expected insecure value to be [null] (YANG empty leaf), got %#v", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageInsecureDefaultOmitted verifies that when insecure is
+// not set (defaults to false), the "insecure" field is omitted from the
+// import payload (nil interface{} is stripped by omitempty).
+func TestUnitTenantImageInsecureDefaultOmitted(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageNoInsecureConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "insecure", "false"),
+					func(s *terraform.State) error {
+						if st.capturedBody == nil {
+							return fmt.Errorf("import endpoint was never called")
+						}
+						// When insecure is false, importImage leaves Insecure
+						// as nil (interface{}), which omitempty strips from JSON.
+						// So the key should be absent entirely.
+						if v, ok := st.capturedBody["insecure"]; ok {
+							return fmt.Errorf("expected insecure key to be absent from request body, got %v", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageReadAfterImportHasCorrectState verifies the full
+// import → read round-trip: after ImportState, the subsequent Read must
+// populate id, image_name, and status correctly. This exercises both
+// the ImportState fix (setting image_name) and the
+// tenantImageResourceModeltoState fix (setting Id).
+func TestUnitTenantImageReadAfterImportHasCorrectState(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		fmt.Sprintf("%s/%s", testAccImageRemotePath, testAccImageName),
+	})
+	_ = st
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create so there is state to import against
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+				),
+			},
+			// Step 2: Import and verify the full state round-trip
+			{
+				ResourceName:      "f5os_tenant_image.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
+				// After import + read, verify all computed fields
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "image_name", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "status", "replicated"),
+				),
+			},
+		},
+	})
+}
+
+// testAccTenantImageInsecureTrueConfig exercises the insecure=true flag
+// to verify it appears in the import API payload.
+var testAccTenantImageInsecureTrueConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name  = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images"
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageRemoteHost)
+
+// ---------------------------------------------------------------------------
+// Unit tests for insecure + protocol combination and http protocol rejection
+// ---------------------------------------------------------------------------
+
+// TestUnitTenantImageInsecureWithHTTPSProtocol verifies that when both
+// insecure=true and protocol="https" are set, the import payload contains
+// both fields with the correct encoding: protocol as "https" and insecure
+// as [null] (RFC 7951 YANG empty leaf).
+func TestUnitTenantImageInsecureWithHTTPSProtocol(t *testing.T) {
+	st := setupTenantImageMock(t, []string{
+		"v17.1.0.1/daily/current/VM/BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+	})
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageInsecureHTTPSConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "insecure", "true"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "protocol", "https"),
+					func(s *terraform.State) error {
+						if st.capturedBody == nil {
+							return fmt.Errorf("import endpoint was never called")
+						}
+						// Verify protocol is present and correct.
+						if v, ok := st.capturedBody["protocol"]; !ok || v != "https" {
+							return fmt.Errorf("expected protocol=https in request body, got %v", v)
+						}
+						// Verify insecure is encoded as [null] per RFC 7951.
+						v, ok := st.capturedBody["insecure"]
+						if !ok {
+							return fmt.Errorf("expected insecure key present in request body, but it was absent")
+						}
+						arr, isArr := v.([]interface{})
+						if !isArr || len(arr) != 1 || arr[0] != nil {
+							return fmt.Errorf("expected insecure value to be [null] (YANG empty leaf), got %#v", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+var testAccTenantImageInsecureHTTPSConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name  = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images"
+  protocol    = "https"
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageRemoteHost)
+
+// TestUnitTenantImageHTTPProtocolRejected verifies that protocol="http"
+// is rejected at plan time by the schema validator. The F5OS RESTCONF API
+// does not support HTTP for file transfers so it was removed from the
+// allowed protocol list.
+func TestUnitTenantImageHTTPProtocolRejected(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "f5os_tenant_image" "http_test" {
+  image_name  = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host = "10.0.0.1"
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images"
+  protocol    = "http"
+  timeout     = 360
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)value must be one of`),
+			},
+		},
+	})
+}
+
+// TestUnitTenantImageInsecurePayloadSerialization directly tests that
+// F5ReqTenantImage serializes the insecure field as [null] (RFC 7951 YANG
+// empty leaf) when set, and omits it entirely when nil.
+func TestUnitTenantImageInsecurePayloadSerialization(t *testing.T) {
+	// Case 1: insecure enabled — should serialize as [null]
+	req := &f5ossdk.F5ReqTenantImage{
+		Insecure:   []interface{}{nil},
+		RemoteHost: "10.0.0.1",
+		RemoteFile: "img/test.qcow2",
+		LocalFile:  "images/tenant",
+		Protocol:   "https",
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal F5ReqTenantImage with insecure: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal serialized body: %v", err)
+	}
+	v, ok := decoded["insecure"]
+	if !ok {
+		t.Fatal("Expected 'insecure' key in serialized JSON, but it was absent")
+	}
+	arr, isArr := v.([]interface{})
+	if !isArr || len(arr) != 1 || arr[0] != nil {
+		t.Fatalf("Expected insecure to serialize as [null], got %#v", v)
+	}
+
+	// Case 2: insecure disabled (nil) — field should be omitted
+	req2 := &f5ossdk.F5ReqTenantImage{
+		RemoteHost: "10.0.0.1",
+		RemoteFile: "img/test.qcow2",
+		LocalFile:  "images/tenant",
+		Protocol:   "https",
+	}
+	body2, err := json.Marshal(req2)
+	if err != nil {
+		t.Fatalf("Failed to marshal F5ReqTenantImage without insecure: %v", err)
+	}
+	var decoded2 map[string]interface{}
+	if err := json.Unmarshal(body2, &decoded2); err != nil {
+		t.Fatalf("Failed to unmarshal serialized body: %v", err)
+	}
+	if _, ok := decoded2["insecure"]; ok {
+		t.Fatalf("Expected 'insecure' key to be absent from serialized JSON when nil, but it was present: %s", string(body2))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for uncommitted fixes (ImportState + tenantImageResourceModeltoState)
+// ---------------------------------------------------------------------------
+
+// testAccGetExistingImageName returns the name of a tenant image that is known
+// to exist on the DUT. It queries the device directly and prefers a non-in-use
+// image so that post-test destroy can delete it. If all images are in-use, it
+// falls back to the first image found. Tests that need an existing image should
+// call this rather than hardcoding image names, because different DUTs have
+// different images.
+func testAccGetExistingImageName(t *testing.T) string {
+	t.Helper()
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create client to discover images: %v", err)
+	}
+	resp, err := client.GetTenantImagesInfo()
+	if err != nil {
+		t.Skipf("Cannot list images on device: %v", err)
+	}
+	if len(resp.Images) == 0 {
+		t.Skip("No tenant images on device — cannot run this acceptance test")
+	}
+	// Prefer a non-in-use image so post-test destroy can delete it.
+	for _, img := range resp.Images {
+		if !img.InUse {
+			return img.Name
+		}
+	}
+	// All images are in-use — fall back to first (post-test destroy will fail).
+	return resp.Images[0].Name
+}
+
+// testAccCheckTenantImageStatusOnDevice queries the device directly and
+// verifies that the named image has the expected status.
+func testAccCheckTenantImageStatusOnDevice(imageName, expectedStatus string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newTenantImageClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		resp, err := client.GetImage(imageName)
+		if err != nil {
+			return fmt.Errorf("GetImage(%q) failed: %w", imageName, err)
+		}
+		if resp == nil || len(resp.TenantImages) == 0 {
+			return fmt.Errorf("image %q not found on device", imageName)
+		}
+		actual := resp.TenantImages[0].Status
+		if actual != expectedStatus {
+			return fmt.Errorf("image %q status: expected %q on device, got %q", imageName, expectedStatus, actual)
+		}
+		return nil
+	}
+}
+
+// TestAccTenantImageImportStateSetsImageName verifies the ImportState fix:
+// after terraform import, both "id" and "image_name" must be populated in
+// state, and the subsequent Read must fill in "status". Before the fix,
+// ImportState only set "id", causing image_name to be null after import.
+//
+// This test adopts an existing in-use image on the device (no actual import
+// transfer is triggered). CheckDestroy tolerates in-use images.
+func TestAccTenantImageImportStateSetsImageName(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+	imageName := testAccGetExistingImageName(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create — adopts the pre-existing image.
+			{
+				Config: testAccTenantImageImportFixConfig(imageName, 360),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "image_name", imageName),
+					resource.TestCheckResourceAttrSet("f5os_tenant_image.import_fix_test", "status"),
+					testAccCheckTenantImageExistsOnDevice(imageName),
+				),
+			},
+			// Step 2: Import and verify the full round-trip.
+			// Before the fix, ImportStateVerify would fail because
+			// image_name was null after import (only id was set).
+			{
+				ResourceName:      "f5os_tenant_image.import_fix_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// After import + read, both id and image_name must be
+					// populated and status must come from the device API.
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "image_name", imageName),
+					resource.TestCheckResourceAttrSet("f5os_tenant_image.import_fix_test", "status"),
+					testAccCheckTenantImageExistsOnDevice(imageName),
+				),
+			},
+		},
+	})
+}
+
+// TestAccTenantImageUpdatePreservesState verifies the tenantImageResourceModeltoState fix:
+// after an in-place Update (timeout change), "id", "image_name", and "status"
+// must all survive. Before the fix, tenantImageResourceModeltoState did not set
+// data.Id, so Update could leave Id inconsistent.
+//
+// This test also verifies the status field via direct API query to ensure the
+// Terraform state matches the actual device state.
+func TestAccTenantImageUpdatePreservesState(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+	imageName := testAccGetExistingImageName(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with timeout=360. Image already exists so
+			// Create skips import and reads back the state.
+			{
+				Config: testAccTenantImageImportFixConfig(imageName, 360),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "image_name", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "timeout", "360"),
+					resource.TestCheckResourceAttrSet("f5os_tenant_image.import_fix_test", "status"),
+					testAccCheckTenantImageExistsOnDevice(imageName),
+				),
+			},
+			// Step 2: Change timeout to 600 — must be an in-place update
+			// (no destroy+recreate). All fields must survive.
+			{
+				Config: testAccTenantImageImportFixConfig(imageName, 600),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "image_name", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "timeout", "600"),
+					resource.TestCheckResourceAttrSet("f5os_tenant_image.import_fix_test", "status"),
+					testAccCheckTenantImageExistsOnDevice(imageName),
+				),
+			},
+		},
+	})
+}
+
+// TestAccTenantImageStatusFromDevice verifies that the "status" field in
+// Terraform state matches the actual image status reported by the device API.
+// This exercises tenantImageResourceModeltoState's mapping of the status field
+// and confirms it with a direct API check.
+func TestAccTenantImageStatusFromDevice(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+	imageName := testAccGetExistingImageName(t)
+
+	// Pre-query the device to get the expected status.
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create client: %v", err)
+	}
+	resp, err := client.GetImage(imageName)
+	if err != nil || resp == nil || len(resp.TenantImages) == 0 {
+		t.Skipf("Cannot query image %q: %v", imageName, err)
+	}
+	expectedStatus := resp.TenantImages[0].Status
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageImportFixConfig(imageName, 360),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "image_name", imageName),
+					// Verify Terraform state's status matches the device
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_fix_test", "status", expectedStatus),
+					// Also verify via direct API call
+					testAccCheckTenantImageStatusOnDevice(imageName, expectedStatus),
+				),
+			},
+		},
+	})
+}
+
+// testAccTenantImageImportFixConfig generates HCL for the import/update fix
+// acceptance tests. It uses a minimal config that adopts an existing image
+// on the device without triggering an actual import transfer.
+func testAccTenantImageImportFixConfig(imageName string, timeout int) string {
+	return fmt.Sprintf(`
+resource "f5os_tenant_image" "import_fix_test" {
+  image_name  = %q
+  remote_host = %q
   remote_path = "v17.1.0.1/daily/current/VM"
   local_path  = "images/tenant"
-  timeout = 360
+  insecure    = true
+  timeout     = %d
+}
+`, imageName, testAccImageRemoteHost, timeout)
+}
+
+// ---------------------------------------------------------------------------
+// HCL configs for attribute-change RequiresReplace tests
+// ---------------------------------------------------------------------------
+
+var testAccTenantImageProtocolChangedConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name      = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = %q
+  remote_path     = "v17.1.0.1/daily/current/VM"
+  local_path      = "images"
+  protocol        = "https"
+  remote_user     = "admin"
+  remote_password = "secret123"
+  remote_port     = 2222
+  timeout         = 360
+}
+`, testAccImageRemoteHost)
+
+var testAccTenantImageRemotePortChangedConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name      = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = %q
+  remote_path     = "v17.1.0.1/daily/current/VM"
+  local_path      = "images"
+  protocol        = "scp"
+  remote_user     = "admin"
+  remote_password = "secret123"
+  remote_port     = 3333
+  timeout         = 360
+}
+`, testAccImageRemoteHost)
+
+var testAccTenantImageRemoteUserChangedConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "test" {
+  image_name      = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = %q
+  remote_path     = "v17.1.0.1/daily/current/VM"
+  local_path      = "images"
+  protocol        = "scp"
+  remote_user     = "operator"
+  remote_password = "secret123"
+  remote_port     = 2222
+  timeout         = 360
+}
+`, testAccImageRemoteHost)
+
+const testAccTenantImageRemoteHostChangedConfig = `
+resource "f5os_tenant_image" "test" {
+  image_name      = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
+  remote_host     = "mirror.olympus.f5net.com"
+  remote_path     = "v17.1.0.1/daily/current/VM"
+  local_path      = "images"
+  protocol        = "scp"
+  remote_user     = "admin"
+  remote_password = "secret123"
+  remote_port     = 2222
+  timeout         = 360
 }
 `
 
-const testAccTenantImageCreateTC2ResourceConfig = `
+// TestUnitTenantImageGetImageErrorStillImports verifies the fix where the
+// initial GetImage call in Create returns an error alongside a non-nil
+// response with populated TenantImages. Before the fix, the condition only
+// checked `resp1Byte == nil || len(resp1Byte.TenantImages) == 0`, so if
+// GetImage returned (non-nil-with-data, error) the import block would be
+// skipped entirely — silently swallowing the error. The fix adds `getErr != nil`
+// to the condition so the import is always attempted when GetImage fails.
+//
+// The mock simulates this by returning HTTP 200 with valid image JSON on the
+// first GET (so the client parses a non-nil response), but wrapping it in an
+// error response structure for the "uri keypath not found" path. To make the
+// test deterministic, we instead return HTTP 500 on the first GetImage call
+// (which makes the client return nil, error), then HTTP 200 with empty body
+// on the second call (post-import existence check during Create), and HTTP 200
+// with full image data on all subsequent calls (Read/Update/Delete).
+func TestUnitTenantImageGetImageErrorStillImports(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	var getImageCallCount int
+	var importCalled bool
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		getImageCallCount++
+		if getImageCallCount == 1 {
+			// First GetImage in Create: return HTTP 500 to simulate a
+			// transient API error. The client returns (nil, error).
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-message":"internal server error"}]}}`)
+		} else {
+			// All subsequent calls: image exists
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"f5-tenant-images:image": [{
+				"name": "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle",
+				"in-use": false,
+				"type": "vm-image",
+				"status": "replicated",
+				"date": "2023-3-27",
+				"size": "2.27 GB"}]}`)
+		}
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/import", func(w http.ResponseWriter, r *http.Request) {
+		importCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", "")
+	})
+	mux.HandleFunc("/restconf/data/f5-utils-file-transfer:file/transfer-operations/transfer-operation", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_image_transfer_status.json"))
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/remove", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"f5-tenant-images:output":{"result":"Successful."}}`)
+	})
+
+	defer teardown()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageCreateTC2ResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "id", "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.test", "status", "replicated"),
+					func(s *terraform.State) error {
+						if !importCalled {
+							return fmt.Errorf("import endpoint was never called; GetImage error was silently swallowed")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAccTenantImageCreateExistingImageSkipsImport verifies the Create path
+// when the image already exists on the device. The first GetImage call
+// succeeds (no error, non-empty TenantImages), so the import block is
+// correctly skipped — exercising the right-hand side of the condition:
+//
+//	if getErr != nil || resp1Byte == nil || len(resp1Byte.TenantImages) == 0 {
+//
+// The test adopts an existing in-use image, verifies Terraform state is
+// populated from the device API (id, image_name, status), and confirms the
+// device state via a direct API query that bypasses Read.
+//
+// The corresponding error-path (getErr != nil) is covered by the unit test
+// TestUnitTenantImageGetImageErrorStillImports, which uses a mock server to
+// simulate an HTTP 500 on the first GetImage and verifies the import is
+// still attempted.
+//
+// NOTE: If the only image on the device is in-use, the post-test destroy
+// will fail with "is in use". This is expected on shared DUTs. The test
+// steps themselves (Create, Check, Import) still validate correctly.
+func TestAccTenantImageCreateExistingImageSkipsImport(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+	imageName := testAccGetExistingImageName(t)
+
+	// Pre-query the device to get the expected status for verification.
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create client: %v", err)
+	}
+	imgResp, err := client.GetImage(imageName)
+	if err != nil || imgResp == nil || len(imgResp.TenantImages) == 0 {
+		t.Skipf("Cannot query image %q: %v", imageName, err)
+	}
+	expectedStatus := imgResp.TenantImages[0].Status
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create — image already exists, GetImage succeeds,
+			// import is skipped. Verify state from device API.
+			{
+				Config: testAccTenantImageExistingImageConfig(imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.existing_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.existing_test", "image_name", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.existing_test", "status", expectedStatus),
+					testAccCheckTenantImageExistsOnDevice(imageName),
+					testAccCheckTenantImageStatusOnDevice(imageName, expectedStatus),
+				),
+			},
+			// Step 2: Import and verify round-trip.
+			{
+				ResourceName:      "f5os_tenant_image.existing_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
+			},
+		},
+	})
+}
+
+func testAccTenantImageExistingImageConfig(imageName string) string {
+	return fmt.Sprintf(`
+resource "f5os_tenant_image" "existing_test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = 360
+}
+`, imageName, testAccImageRemoteHost)
+}
+
+// TestUnitTenantImageRemotePathConflictsWithUploadFromPath verifies that
+// the remote_path attribute has a ConflictsWith validator for
+// upload_from_path. Setting both must produce a validation error.
+func TestUnitTenantImageRemotePathConflictsWithUploadFromPath(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "f5os_tenant_image" "conflict_test" {
+  image_name       = "test.qcow2.zip.bundle"
+  remote_path      = "v17/VM"
+  upload_from_path = "/tmp/test.qcow2.zip.bundle"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)conflict`),
+			},
+		},
+	})
+}
+
+// testAccTenantImageRequiresReplaceConfig changes remote_path relative to
+// testAccTenantImageCreateTC2ResourceConfig, which should trigger
+// RequiresReplace (destroy + recreate).
+var testAccTenantImageRequiresReplaceConfig = fmt.Sprintf(`
 resource "f5os_tenant_image" "test" {
   image_name  = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
-  remote_host = "spkapexsrvc01.olympus.f5net.com"
-  remote_path = "v17.1.0.1/daily/current/VM"
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/previous/VM"
   local_path  = "images"
-  timeout = 360
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageRemoteHost)
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for importWait changes (tenant.go)
+//
+// These tests exercise the importWait fixes against a real F5OS device:
+//   - Nil-map guards (the happy path proves no panic on real API responses)
+//   - New error status checks ("Couldn't connect to server",
+//     "Peer certificate cannot be authenticated")
+//   - The for→if fix plus "File Transfer Initiated" recognition
+//     (the successful import passes through these code paths)
+// ---------------------------------------------------------------------------
+
+// TestAccTenantImageImportWaitBadHost verifies that importing from a
+// non-routable host causes importWait to surface the "Couldn't connect
+// to server" error — a status check that was added in the importWait fix.
+//
+// Before the fix, this status was not recognized; importWait would fall
+// through to the end of the loop iteration without returning an error,
+// and the caller would spin until the timeout expired. With the fix,
+// importWait returns immediately with the error.
+//
+// The test uses 10.255.255.1 (non-routable) so the F5OS device cannot
+// reach it, and a short timeout (60s) so the test fails quickly if the
+// error is not detected.
+func TestAccTenantImageImportWaitBadHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTenantImageBadHostConfig,
+				ExpectError: regexp.MustCompile(`(?i)connect to server|connection refused|timed out|communication failure|Unable to Import`),
+			},
+		},
+	})
+}
+
+const testAccTenantImageBadHostConfig = `
+resource "f5os_tenant_image" "bad_host_test" {
+  image_name  = "BIGIP-nonexistent-image.qcow2.zip.bundle"
+  remote_host = "10.255.255.1"
+  remote_path = "v17/daily/current/VM"
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = 60
 }
 `
 
-const testAccTenantImageCreateTC2ModifyResourceConfig = `
-resource "f5os_tenant_image" "test" {
-  image_name  = "BIGIP-17.1.0.1-0.0.4.ALL-F5OS.qcow2.zip.bundle"
-  remote_host = "spkapexsrvc01.olympus.f5net.com"
-  remote_path = "v17.1.0.1/daily/current/VM"
-  local_path  = "images"
-  timeout = 380
+// TestAccTenantImageImportWaitCertError verifies that importing via HTTPS
+// from a host whose certificate cannot be authenticated causes importWait
+// to surface the "Peer certificate cannot be authenticated" error — a
+// status check that was added in the importWait fix.
+//
+// The test uses a known remote host without the insecure flag, so the
+// device's HTTPS client rejects the server certificate.
+func TestAccTenantImageImportWaitCertError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTenantImageCertErrorConfig,
+				ExpectError: regexp.MustCompile(`(?i)certificate|Peer certificate cannot be authenticated|transfer`),
+			},
+		},
+	})
 }
-`
+
+var testAccTenantImageCertErrorConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "cert_error_test" {
+  image_name  = "BIGIP-cert-error-nonexistent.qcow2.zip.bundle"
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images/tenant"
+  insecure    = false
+  timeout     = 90
+}
+`, testAccImageRemoteHost)
+
+// TestAccTenantImageImportWaitSuccess verifies the happy path through the
+// provider's Create and Read lifecycle using a real device. It adopts an
+// existing image on the device (no actual remote import) and verifies that:
+//   - Create does not panic when processing real API responses (nil guards)
+//   - GetImage and the transfer-status endpoint return data that the fixed
+//     importWait can safely handle
+//   - State is correctly populated (id, image_name, status)
+//   - A direct API query confirms the device state matches Terraform state
+//
+// The test uses testAccGetExistingImageName to dynamically discover an image
+// on the device, so it works on any DUT without hardcoded image names.
+func TestAccTenantImageImportWaitSuccess(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+	imageName := testAccGetExistingImageName(t)
+
+	// Pre-query the device to get the expected status for verification.
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Skipf("Cannot create client: %v", err)
+	}
+	imgResp, err := client.GetImage(imageName)
+	if err != nil || imgResp == nil || len(imgResp.TenantImages) == 0 {
+		t.Skipf("Cannot query image %q: %v", imageName, err)
+	}
+	expectedStatus := imgResp.TenantImages[0].Status
+	if imgResp.TenantImages[0].InUse {
+		// If the image is in-use, the post-test destroy will fail.
+		// We can still run the test to validate Create+Read but must
+		// accept the destroy error. Use a wrapper that ignores it.
+		t.Logf("Image %q is in-use; post-test destroy will fail (expected on shared DUTs)", imageName)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageImportWaitSuccessConfig(imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_success_test", "id", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_success_test", "image_name", imageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.import_success_test", "status", expectedStatus),
+					// Direct device verification — bypasses Read method.
+					testAccCheckTenantImageExistsOnDevice(imageName),
+					testAccCheckTenantImageStatusOnDevice(imageName, expectedStatus),
+				),
+			},
+		},
+	})
+}
+
+func testAccTenantImageImportWaitSuccessConfig(imageName string) string {
+	return fmt.Sprintf(`
+resource "f5os_tenant_image" "import_success_test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = "v17/dist/release/VM"
+  local_path  = "images/tenant"
+  insecure    = true
+  timeout     = 360
+}
+`, imageName, testAccImageRemoteHost)
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for insecure [null] encoding (RFC 7951) and protocol removal
+// ---------------------------------------------------------------------------
+
+// TestAccTenantImageInsecureHTTPSImport verifies that the fixed insecure
+// encoding ([null] per RFC 7951) is accepted by a real F5OS device when
+// importing via HTTPS. This is the primary acceptance test for the
+// insecure/protocol fix.
+//
+// The test imports the standard test image using protocol="https" and
+// insecure=true. If the image already exists, Create adopts it without
+// calling the import endpoint — which still validates that the provider
+// accepts the config and populates state correctly. If the image does NOT
+// exist, Create triggers a real import call whose payload now contains
+// "insecure": [null] instead of the old "insecure": "" that the device
+// rejected.
+func TestAccTenantImageInsecureHTTPSImport(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantImageInsecureHTTPSImportConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant_image.insecure_https_test", "id", testAccImageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.insecure_https_test", "image_name", testAccImageName),
+					resource.TestCheckResourceAttr("f5os_tenant_image.insecure_https_test", "insecure", "true"),
+					resource.TestCheckResourceAttr("f5os_tenant_image.insecure_https_test", "protocol", "https"),
+					testAccCheckTenantImageExistsOnDevice(testAccImageName),
+				),
+			},
+			// ImportState round-trip
+			{
+				ResourceName:      "f5os_tenant_image.insecure_https_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"local_path", "remote_host", "remote_path", "remote_user",
+					"remote_password", "remote_port", "protocol", "insecure",
+					"upload_from_path", "timeout",
+				},
+			},
+		},
+	})
+}
+
+var testAccTenantImageInsecureHTTPSImportConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "insecure_https_test" {
+  image_name  = %q
+  remote_host = %q
+  remote_path = %q
+  local_path  = "images/tenant"
+  protocol    = "https"
+  insecure    = true
+  timeout     = 360
+}
+`, testAccImageName, testAccImageRemoteHost, testAccImageRemotePath)
+
+// TestAccTenantImageInsecureDirectAPIImport bypasses Terraform and calls the
+// f5osclient ImportImage function directly with the fixed [null] insecure
+// encoding against a real device. This validates that the F5OS RESTCONF API
+// at /f5-utils-file-transfer:file/import accepts the RFC 7951 YANG empty
+// leaf encoding. Unlike TestAccTenantImageInsecureHTTPSImport (which may
+// adopt an existing image and skip the import call), this test always hits
+// the import endpoint.
+//
+// It uses a non-existent image name so the import will fail with a transfer
+// error (unreachable file), NOT with "invalid value for: insecure". This
+// proves the insecure field encoding is accepted by the API.
+func TestAccTenantImageInsecureDirectAPIImport(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheck(t)
+
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Fatalf("Cannot create client: %v", err)
+	}
+
+	importConfig := &f5ossdk.F5ReqTenantImage{
+		RemoteHost: testAccImageRemoteHost,
+		RemoteFile: "nonexistent-path/BIGIP-fake-insecure-test.qcow2.zip.bundle",
+		LocalFile:  "images/tenant",
+		Protocol:   "https",
+		Insecure:   []interface{}{nil}, // RFC 7951 YANG empty leaf: [null]
+	}
+
+	// We expect ImportImage to NOT fail with "invalid value for: insecure".
+	// It will fail for other reasons (file not found, transfer timeout, etc.)
+	// which is fine — we only care that the insecure field was accepted.
+	_, err = client.ImportImage(importConfig, 60) // short timeout; we don't need it to complete
+	if err != nil {
+		errStr := err.Error()
+		if strings.Contains(errStr, "invalid value") && strings.Contains(errStr, "insecure") {
+			t.Fatalf("API rejected insecure field encoding: %v", err)
+		}
+		// Any other error is expected (file not found, timeout, etc.)
+		t.Logf("Import failed as expected (file doesn't exist): %v", err)
+	}
+}
+
+// TestAccTenantImageInsecureFalseHTTPSCertError verifies that when
+// insecure=false (the default), the insecure field is omitted from the
+// import payload and the F5OS device's HTTPS client rejects the server
+// certificate. This is the counterpart to TestAccTenantImageInsecureHTTPSImport
+// and validates that omitting insecure (nil, omitempty) still produces
+// the expected certificate verification behavior.
+//
+// This test overlaps with TestAccTenantImageImportWaitCertError but
+// explicitly sets protocol="https" to test the combination.
+func TestAccTenantImageInsecureFalseHTTPSCertError(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckWithSetup(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTenantImageInsecureFalseHTTPSConfig,
+				ExpectError: regexp.MustCompile(`(?i)certificate|Peer certificate cannot be authenticated|Unable to Import`),
+			},
+		},
+	})
+}
+
+var testAccTenantImageInsecureFalseHTTPSConfig = fmt.Sprintf(`
+resource "f5os_tenant_image" "cert_test" {
+  image_name  = "BIGIP-insecure-false-test-nonexistent.qcow2.zip.bundle"
+  remote_host = %q
+  remote_path = "v17.1.0.1/daily/current/VM"
+  local_path  = "images/tenant"
+  protocol    = "https"
+  insecure    = false
+  timeout     = 90
+}
+`, testAccImageRemoteHost)
+
+// TestAccTenantImageTransferStatusShape queries the transfer-status
+// endpoint directly (bypassing Terraform entirely) and verifies that the
+// real API response has the structure that the importWait nil guards
+// protect against. This is not a Terraform resource test — it validates
+// our assumptions about the API response shape.
+//
+// Specifically it checks:
+//   - The response is valid JSON
+//   - The top-level key "f5-utils-file-transfer:transfer-operation" exists
+//   - Its value is an array
+//   - Each entry is an object with string keys "remote-file-path" and "status"
+func TestAccTenantImageTransferStatusShape(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	testAccPreCheckWithSetup(t)
+
+	client, err := newTenantImageClientFromEnv()
+	if err != nil {
+		t.Fatalf("Cannot create client: %v", err)
+	}
+
+	// Call the same endpoint that getImporttransferStatus uses.
+	resp, err := client.GetRequest(
+		"/f5-utils-file-transfer:file/transfer-operations/transfer-operation",
+	)
+	if err != nil {
+		// A 404 (no transfers) is acceptable — the nil guard handles this.
+		t.Logf("GetRequest returned error (may be empty): %v", err)
+		return
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(resp, &raw); err != nil {
+		t.Fatalf("Response is not valid JSON: %v\nBody: %s", err, string(resp))
+	}
+
+	opsRaw, ok := raw["f5-utils-file-transfer:transfer-operation"]
+	if !ok {
+		t.Fatal("Response missing key 'f5-utils-file-transfer:transfer-operation'")
+	}
+
+	ops, ok := opsRaw.([]interface{})
+	if !ok {
+		t.Fatalf("Expected transfer-operation to be an array, got %T", opsRaw)
+	}
+
+	if len(ops) == 0 {
+		t.Log("No transfer operations on device; shape is valid but empty")
+		return
+	}
+
+	// Verify at least the first entry has the expected fields.
+	first, ok := ops[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected first entry to be a map, got %T", ops[0])
+	}
+
+	if _, ok := first["remote-file-path"]; !ok {
+		t.Error("First entry missing 'remote-file-path' key")
+	}
+	if _, ok := first["status"]; !ok {
+		t.Error("First entry missing 'status' key")
+	}
+
+	t.Logf("Transfer status shape validated: %d operations found", len(ops))
+}

--- a/internal/provider/tenant_resource.go
+++ b/internal/provider/tenant_resource.go
@@ -94,6 +94,7 @@ func (r *TenantResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"deployment_file": schema.StringAttribute{
 				MarkdownDescription: "Deployment file used for BIG-IP-Next .\nRequired for if `type` is `BIG-IP-Next`.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"type": schema.StringAttribute{
 				MarkdownDescription: "Name of the tenant image to be used.\nRequired for create operations",
@@ -387,7 +388,24 @@ func (r *TenantResource) tenantResourceModeltoState(ctx context.Context, respDat
 	data.MgmtIP = types.StringValue(respData.F5TenantsTenant[0].State.MgmtIp)
 	data.MgmtPrefix = types.Int64Value(int64(respData.F5TenantsTenant[0].State.PrefixLength))
 	data.CpuCores = types.Int64Value(int64(respData.F5TenantsTenant[0].State.VcpuCoresPerNode))
-	data.Nodes, _ = types.ListValueFrom(ctx, types.Int64Type, respData.F5TenantsTenant[0].Config.Nodes)
+	if respData.F5TenantsTenant[0].Config.Nodes != nil {
+		nodesList, diags := types.ListValueFrom(ctx, types.Int64Type, respData.F5TenantsTenant[0].Config.Nodes)
+		if diags.HasError() {
+			tflog.Warn(ctx, "failed to convert nodes to list", map[string]interface{}{"nodes": respData.F5TenantsTenant[0].Config.Nodes})
+		}
+		data.Nodes = nodesList
+	} else {
+		data.Nodes = types.ListNull(types.Int64Type)
+	}
+	if respData.F5TenantsTenant[0].Config.Vlans != nil {
+		vlansList, diags := types.ListValueFrom(ctx, types.Int64Type, respData.F5TenantsTenant[0].Config.Vlans)
+		if diags.HasError() {
+			tflog.Warn(ctx, "failed to convert vlans to list", map[string]interface{}{"vlans": respData.F5TenantsTenant[0].Config.Vlans})
+		}
+		data.Vlans = vlansList
+	} else {
+		data.Vlans = types.ListNull(types.Int64Type)
+	}
 	data.MgmtGateway = types.StringValue(respData.F5TenantsTenant[0].State.Gateway)
 	data.Status = types.StringValue(respData.F5TenantsTenant[0].State.Status)
 	data.DagIpv6prefixLength = types.Int64Value(int64(respData.F5TenantsTenant[0].State.DagIpv6PrefixLength))
@@ -413,6 +431,12 @@ func (r *TenantResource) tenantResourceModeltoState(ctx context.Context, respDat
 		data.Memory = types.Int64Value(int64(memoryInt))
 	}
 	data.Cryptos = types.StringValue(respData.F5TenantsTenant[0].State.Cryptos)
+	data.Type = types.StringValue(respData.F5TenantsTenant[0].State.Type)
+	if respData.F5TenantsTenant[0].Config.DeploymentFile != "" {
+		data.DeploymentFile = types.StringValue(respData.F5TenantsTenant[0].Config.DeploymentFile)
+	} else if data.DeploymentFile.IsUnknown() {
+		data.DeploymentFile = types.StringNull()
+	}
 }
 
 func (r *TenantResource) getTenantCreateConfig(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) *f5ossdk.F5ReqTenants {

--- a/internal/provider/tenant_resource_test.go
+++ b/internal/provider/tenant_resource_test.go
@@ -3,60 +3,44 @@ package provider
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
+	f5ossdk "gitswarm.f5net.com/terraform-providers/f5osclient"
 )
 
 func TestAccTenantDeployResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantDestroy,
 		Steps: []resource.TestStep{
-			// Read testing
 			{
-				Config: testAccTenantDeployResourceConfig,
+				Config: testAccTenantDeployResourceConfigFunc(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "id", "testtenant-ecosys2"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "name", "testtenant-ecosys2"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "image_name", "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "image_name", tenantTestImage()),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_ip", "10.10.10.26"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_gateway", "10.10.10.1"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "type", "BIG-IP"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "status", "Configured"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.0", "1"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.#", "1"),
+					testAccCheckTenantTypeOnDevice("testtenant-ecosys2", "BIG-IP"),
 				),
 			},
-			// ImportState testing
 			{
 				ResourceName:      "f5os_tenant.test2",
 				ImportState:       true,
-				ImportStateVerify: false,
-			},
-		},
-	})
-}
-
-func TestAccTenantDeployResourceTC5(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Read testing
-			{
-				Config: testAccTenantDeployTC5,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "id", "testtenant-ecosys03"),
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "name", "testtenant-ecosys03"),
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "image_name", "BIG-IP-Next-20.0.1-2.123.17"),
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "mgmt_ip", "100.10.100.110"),
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "mgmt_gateway", "100.10.100.1"),
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "type", "BIG-IP-Next"),
-					resource.TestCheckResourceAttr("f5os_tenant.velos_bigip_next_tenant_tc5", "status", "Configured"),
-				),
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",
+					"virtual_disk_size",
+				},
 			},
 		},
 	})
@@ -66,34 +50,31 @@ func TestAccTenantDeployResourceTC4(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantDestroy,
 		Steps: []resource.TestStep{
-			// Read testing
+			// Step 1: Create
 			{
-				Config: testAccTenantDeployResourceConfig,
+				Config: testAccTenantDeployResourceConfigFunc(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "id", "testtenant-ecosys2"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "name", "testtenant-ecosys2"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "image_name", "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "image_name", tenantTestImage()),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_ip", "10.10.10.26"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_gateway", "10.10.10.1"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "type", "BIG-IP"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "status", "Configured"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.0", "1"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.#", "1"),
+					testAccCheckTenantTypeOnDevice("testtenant-ecosys2", "BIG-IP"),
 				),
 			},
+			// Step 2: Update mgmt_ip
 			{
-				Config: testAccTenantDeployTC4ResourceConfig,
+				Config: testAccTenantDeployTC4ResourceConfigFunc(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "id", "testtenant-ecosys2"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "name", "testtenant-ecosys2"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "image_name", "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "image_name", tenantTestImage()),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_ip", "10.10.10.27"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_gateway", "10.10.10.1"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "type", "BIG-IP"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "status", "Configured"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.0", "1"),
-					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.#", "1"),
 				),
 			},
 		},
@@ -142,18 +123,22 @@ func TestUnitTenantDeployResourceUnitTC1(t *testing.T) {
 		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_get_status.json"))
 	})
 	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		if r.Method == "GET" && (count == 0 || count == 1 || count == 2) {
+		if r.Method == "DELETE" {
+			w.WriteHeader(http.StatusOK)
+			count++
+			return
+		}
+		if r.Method == "GET" && count <= 4 {
+			w.WriteHeader(http.StatusOK)
 			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_config.json"))
-		} else if r.Method == "GET" && (count == 3 || count == 4 || count == 5) {
+		} else if r.Method == "GET" && count <= 7 {
+			w.WriteHeader(http.StatusOK)
 			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_update_config.json"))
 		} else if r.Method == "GET" {
-			_, _ = fmt.Fprintf(w, `
-			{"ietf-restconf:errors": {"error": [{
-	 				"error-type": "application",
-	 				"error-tag": "invalid-value",
-	 				"error-message": "uri keypath not found"
-	 			}]}}`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors": {"error": [{"error-type": "application","error-tag": "invalid-value","error-message": "uri keypath not found"}]}}`)
+		} else {
+			w.WriteHeader(http.StatusOK)
 		}
 		count++
 	})
@@ -162,7 +147,7 @@ func TestUnitTenantDeployResourceUnitTC1(t *testing.T) {
 		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Read testing
+			// Step 1: Create and verify type is populated from device
 			{
 				Config: testAccTenantDeployResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -175,6 +160,20 @@ func TestUnitTenantDeployResourceUnitTC1(t *testing.T) {
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "status", "Configured"),
 				),
 			},
+			// Step 2: Import — verifies type is populated from the
+			// device API response, not carried over from prior plan.
+			// Before the fix, tenantResourceModeltoState did not set
+			// data.Type so the imported state would have an empty type.
+			{
+				ResourceName:      "f5os_tenant.test2",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",           // not returned by API
+					"virtual_disk_size", // state vs config size mismatch
+				},
+			},
+			// Step 3: Update and verify type is still correct
 			{
 				Config: testAccTenantDeployResourceConfigModify,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -185,6 +184,231 @@ func TestUnitTenantDeployResourceUnitTC1(t *testing.T) {
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "mgmt_gateway", "10.10.10.1"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "type", "BIG-IP"),
 					resource.TestCheckResourceAttr("f5os_tenant.test2", "status", "Configured"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantTypePopulatedOnImport verifies that after terraform import,
+// the "type" attribute is populated from the device API response (State.Type),
+// not preserved from stale plan state. Before the fix that added
+//
+//	data.Type = types.StringValue(respData.F5TenantsTenant[0].State.Type)
+//
+// to tenantResourceModeltoState(), the type field would be empty after import.
+func TestUnitTenantTypePopulatedOnImport(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"f5-tenant-images:image":[{"name":"BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle","in-use":false,"type":"vm-image","status":"replicated","date":"2023-8-17","size":"2.27 GB"}]}`)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2/state", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_get_status.json"))
+	})
+	deleted := false
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "GET" && !deleted {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_config.json"))
+		} else if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value","error-message":"uri keypath not found"}]}}`)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create
+			{
+				Config: testAccTenantDeployResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "type", "BIG-IP"),
+				),
+			},
+			// Step 2: Import — the critical test. During import there
+			// is no prior plan state. The "type" field can ONLY be
+			// populated if tenantResourceModeltoState reads it from
+			// the API response (State.Type). Without the fix, this
+			// assertion would fail with type="" or the ImportStateVerify
+			// would report type missing.
+			{
+				ResourceName:      "f5os_tenant.test2",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",
+					"virtual_disk_size",
+				},
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(states))
+					}
+					typeVal := states[0].Attributes["type"]
+					if typeVal != "BIG-IP" {
+						return fmt.Errorf("expected type %q after import, got %q — tenantResourceModeltoState is not setting data.Type", "BIG-IP", typeVal)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// TestUnitTenantVlansPopulatedFromDevice verifies that when the device API
+// returns a non-nil vlans array, tenantResourceModeltoState populates
+// data.Vlans with the correct values.
+func TestUnitTenantVlansPopulatedFromDevice(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"f5-tenant-images:image":[{"name":"BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle","in-use":false,"type":"vm-image","status":"replicated","date":"2023-8-17","size":"2.27 GB"}]}`)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2/state", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_get_status.json"))
+	})
+	deleted := false
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "GET" && !deleted {
+			w.WriteHeader(http.StatusOK)
+			// Return fixture with vlans: [10, 20, 30]
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_config_multi_vlans.json"))
+		} else if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value","error-message":"uri keypath not found"}]}}`)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantVlansMultiConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.#", "3"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.0", "10"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.1", "20"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "vlans.2", "30"),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitTenantVlansNullWhenDeviceReturnsNone verifies that when the device
+// API response has no vlans field (nil), tenantResourceModeltoState sets
+// data.Vlans to types.ListNull so the state doesn't contain stale values.
+func TestUnitTenantVlansNullWhenDeviceReturnsNone(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"f5-tenant-images:image":[{"name":"BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle","in-use":false,"type":"vm-image","status":"replicated","date":"2023-8-17","size":"2.27 GB"}]}`)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2/state", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_get_status.json"))
+	})
+	deleted := false
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "GET" && !deleted {
+			w.WriteHeader(http.StatusOK)
+			// Return fixture with NO vlans field
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_config_no_vlans.json"))
+		} else if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value","error-message":"uri keypath not found"}]}}`)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantNoVlansConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "name", "testtenant-ecosys2"),
+					resource.TestCheckNoResourceAttr("f5os_tenant.test2", "vlans.#"),
 				),
 			},
 		},
@@ -321,6 +545,434 @@ func TestUnitTenantDeployResourceUnitTC3(t *testing.T) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// Acceptance test: verifies the type field is populated from the device
+// after Create and Import (the fix under test).
+// Uses a real image available on the DUT.
+// ---------------------------------------------------------------------------
+
+// testAccCheckTenantTypeOnDevice queries the device directly and verifies
+// the tenant type field matches the expected value.
+func testAccCheckTenantTypeOnDevice(tenantName, expectedType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newTenantClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		resp, err := client.GetTenant(tenantName)
+		if err != nil {
+			return fmt.Errorf("GetTenant failed: %w", err)
+		}
+		if len(resp.F5TenantsTenant) == 0 {
+			return fmt.Errorf("tenant %q not found on device", tenantName)
+		}
+		actual := resp.F5TenantsTenant[0].State.Type
+		if actual != expectedType {
+			return fmt.Errorf("tenant %q type: expected %q, got %q", tenantName, expectedType, actual)
+		}
+		return nil
+	}
+}
+
+// newTenantClientFromEnv creates a fresh f5osclient session from env vars.
+func newTenantClientFromEnv() (*f5ossdk.F5os, error) {
+	host := os.Getenv("F5OS_HOST")
+	user := os.Getenv("F5OS_USERNAME")
+	if user == "" {
+		user = os.Getenv("F5OS_USER")
+	}
+	pass := os.Getenv("F5OS_PASSWORD")
+	port := 8888
+	if p := os.Getenv("F5OS_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	cfg := &f5ossdk.F5osConfig{
+		Host:             host,
+		User:             user,
+		Password:         pass,
+		Port:             port,
+		DisableSSLVerify: true,
+	}
+	return f5ossdk.NewSession(cfg)
+}
+
+// testAccCheckTenantDestroy verifies the test tenant no longer exists.
+func testAccCheckTenantDestroy(s *terraform.State) error {
+	if os.Getenv("F5OS_HOST") == "" {
+		return nil
+	}
+	client, err := newTenantClientFromEnv()
+	if err != nil {
+		return nil // treat connection failure as destroyed
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "f5os_tenant" {
+			continue
+		}
+		name := rs.Primary.Attributes["name"]
+		if !client.CheckTenantnotexist(name) {
+			return fmt.Errorf("tenant %q still exists after destroy", name)
+		}
+	}
+	return nil
+}
+
+func testAccTenantTypeFieldConfigFunc() string {
+	return fmt.Sprintf(`
+resource "f5os_tenant" "type_test" {
+  name              = "test-type-field"
+  image_name        = %q
+  mgmt_ip           = "10.10.10.50"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 2
+  running_state     = "configured"
+  virtual_disk_size = 83
+}
+`, tenantTestImage())
+}
+
+func TestAccTenantDeployResourceTypeField(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create and verify type is populated in state
+			// AND on the device via direct API check.
+			{
+				Config: testAccTenantTypeFieldConfigFunc(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.type_test", "name", "test-type-field"),
+					resource.TestCheckResourceAttr("f5os_tenant.type_test", "type", "BIG-IP"),
+					resource.TestCheckResourceAttr("f5os_tenant.type_test", "status", "Configured"),
+					// Direct device API verification
+					testAccCheckTenantTypeOnDevice("test-type-field", "BIG-IP"),
+				),
+			},
+			// Step 2: Import — the critical test for the fix. During
+			// import there is no prior plan. The "type" field can ONLY
+			// be populated if tenantResourceModeltoState reads State.Type
+			// from the device. Without the fix, type would be empty.
+			{
+				ResourceName:      "f5os_tenant.type_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",           // not returned by API
+					"virtual_disk_size", // state vs config size may differ
+				},
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test: verifies that vlans are populated in state from the
+// device after Create and Import, and updated correctly.
+// ---------------------------------------------------------------------------
+
+// testAccCheckTenantVlansOnDevice queries the device directly and verifies
+// the tenant config vlans match the expected values.
+func testAccCheckTenantVlansOnDevice(tenantName string, expectedVlans []int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newTenantClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		resp, err := client.GetTenant(tenantName)
+		if err != nil {
+			return fmt.Errorf("GetTenant failed: %w", err)
+		}
+		if len(resp.F5TenantsTenant) == 0 {
+			return fmt.Errorf("tenant %q not found on device", tenantName)
+		}
+		actual := resp.F5TenantsTenant[0].Config.Vlans
+		if len(actual) != len(expectedVlans) {
+			return fmt.Errorf("tenant %q vlans: expected %v, got %v", tenantName, expectedVlans, actual)
+		}
+		for i, v := range expectedVlans {
+			if actual[i] != v {
+				return fmt.Errorf("tenant %q vlans[%d]: expected %d, got %d", tenantName, i, v, actual[i])
+			}
+		}
+		return nil
+	}
+}
+
+// testAccCheckTenantNoVlansOnDevice queries the device and verifies the
+// tenant has no vlans configured. This handles both nil (omitted from JSON)
+// and empty array cases since len(nil) == 0 and len([]int{}) == 0.
+func testAccCheckTenantNoVlansOnDevice(tenantName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newTenantClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		resp, err := client.GetTenant(tenantName)
+		if err != nil {
+			return fmt.Errorf("GetTenant failed: %w", err)
+		}
+		if len(resp.F5TenantsTenant) == 0 {
+			return fmt.Errorf("tenant %q not found on device", tenantName)
+		}
+		actual := resp.F5TenantsTenant[0].Config.Vlans
+		if len(actual) != 0 {
+			return fmt.Errorf("tenant %q expected no vlans, got %v", tenantName, actual)
+		}
+		return nil
+	}
+}
+
+// TestAccTenantVlansPopulatedInState verifies vlans are populated in state
+// from the device after Create and Import, and updated correctly.
+// Note: Vlans are stored as an ordered list (types.ListType), not a set.
+// The F5OS API preserves VLAN ordering, so index-based assertions are valid.
+// Prerequisites: VLANs 3910, 3920, 3930 must exist on the device (range 3900-3999
+// is reserved for testing per the skill safety rules).
+func TestAccTenantVlansPopulatedInState(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with vlans and verify state + device
+			{
+				Config: testAccTenantWithVlansConfigFunc([]int{3910, 3920}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "name", "test-vlans-field"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "type", "BIG-IP"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "status", "Configured"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.#", "2"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.0", "3910"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.1", "3920"),
+					testAccCheckTenantVlansOnDevice("test-vlans-field", []int{3910, 3920}),
+				),
+			},
+			// Step 2: Import — vlans should now survive import because
+			// tenantResourceModeltoState reads Config.Vlans from the
+			// device response.
+			{
+				ResourceName:      "f5os_tenant.vlans_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",
+					"virtual_disk_size",
+				},
+			},
+			// Step 3: Update vlans to a different set
+			{
+				Config: testAccTenantWithVlansConfigFunc([]int{3910, 3920, 3930}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.#", "3"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.0", "3910"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.1", "3920"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "vlans.2", "3930"),
+					testAccCheckTenantVlansOnDevice("test-vlans-field", []int{3910, 3920, 3930}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTenantNoVlansInState(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with no vlans — verify no vlans on device
+			{
+				Config: testAccTenantWithoutVlansConfigFunc(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "name", "test-vlans-field"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "type", "BIG-IP"),
+					resource.TestCheckResourceAttr("f5os_tenant.vlans_test", "status", "Configured"),
+					resource.TestCheckNoResourceAttr("f5os_tenant.vlans_test", "vlans.#"),
+					testAccCheckTenantNoVlansOnDevice("test-vlans-field"),
+				),
+			},
+			// Step 2: Import — vlans should be null after import
+			{
+				ResourceName:      "f5os_tenant.vlans_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",
+					"virtual_disk_size",
+				},
+			},
+		},
+	})
+}
+
+// testAccCheckTenantNoDeploymentFileOnDevice queries the device directly and
+// verifies Config.DeploymentFile is empty for a standard BIG-IP tenant.
+func testAccCheckTenantNoDeploymentFileOnDevice(tenantName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := newTenantClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		resp, err := client.GetTenant(tenantName)
+		if err != nil {
+			return fmt.Errorf("GetTenant failed: %w", err)
+		}
+		if len(resp.F5TenantsTenant) == 0 {
+			return fmt.Errorf("tenant %q not found on device", tenantName)
+		}
+		actual := resp.F5TenantsTenant[0].Config.DeploymentFile
+		if actual != "" {
+			return fmt.Errorf("tenant %q expected no deployment_file, got %q", tenantName, actual)
+		}
+		return nil
+	}
+}
+
+// TestAccTenantDeploymentFileAbsentForBigIP verifies that for a standard
+// BIG-IP tenant, deployment_file is absent in state and empty on device.
+func TestAccTenantDeploymentFileAbsentForBigIP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckTenantDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create standard BIG-IP tenant without deployment_file
+			{
+				Config: testAccTenantBigIPNoDeploymentFileConfigFunc(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.df_bigip_test", "name", "test-df-bigip"),
+					resource.TestCheckResourceAttr("f5os_tenant.df_bigip_test", "type", "BIG-IP"),
+					resource.TestCheckResourceAttr("f5os_tenant.df_bigip_test", "status", "Configured"),
+					resource.TestCheckNoResourceAttr("f5os_tenant.df_bigip_test", "deployment_file"),
+					// Direct device API verification — no deployment_file on device
+					testAccCheckTenantNoDeploymentFileOnDevice("test-df-bigip"),
+				),
+			},
+			// Step 2: Import — deployment_file should remain absent
+			{
+				ResourceName:      "f5os_tenant.df_bigip_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout",
+					"virtual_disk_size",
+				},
+			},
+		},
+	})
+}
+
+func testAccTenantBigIPNoDeploymentFileConfigFunc() string {
+	return fmt.Sprintf(`
+resource "f5os_tenant" "df_bigip_test" {
+  name              = "test-df-bigip"
+  image_name        = %q
+  mgmt_ip           = "10.10.10.42"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 2
+  running_state     = "configured"
+  virtual_disk_size = 83
+}
+`, tenantTestImage())
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test HCL configs
+// ---------------------------------------------------------------------------
+
+// tenantTestImage returns the BIG-IP tenant image name to use in acceptance
+// tests. Set F5OS_TENANT_IMAGE to override the default. Unit tests using the
+// mock server keep the original hardcoded name in their fixtures/constants.
+func tenantTestImage() string {
+	if v := os.Getenv("F5OS_TENANT_IMAGE"); v != "" {
+		return v
+	}
+	return "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
+}
+
+// --- Acceptance test configs (use tenantTestImage()) ---
+
+func testAccTenantDeployResourceConfigFunc() string {
+	return fmt.Sprintf(`
+resource "f5os_tenant" "test2" {
+  name              = "testtenant-ecosys2"
+  image_name        = %q
+  mgmt_ip           = "10.10.10.26"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 2
+  running_state     = "configured"
+  virtual_disk_size = 83
+}
+`, tenantTestImage())
+}
+
+func testAccTenantWithVlansConfigFunc(vlans []int) string {
+	vlanStr := ""
+	for i, v := range vlans {
+		if i > 0 {
+			vlanStr += ", "
+		}
+		vlanStr += fmt.Sprintf("%d", v)
+	}
+	return fmt.Sprintf(`
+resource "f5os_tenant" "vlans_test" {
+  name              = "test-vlans-field"
+  image_name        = %q
+  mgmt_ip           = "10.10.10.51"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 2
+  running_state     = "configured"
+  virtual_disk_size = 83
+  vlans             = [%s]
+}
+`, tenantTestImage(), vlanStr)
+}
+
+func testAccTenantWithoutVlansConfigFunc() string {
+	return fmt.Sprintf(`
+resource "f5os_tenant" "vlans_test" {
+  name              = "test-vlans-field"
+  image_name        = %q
+  mgmt_ip           = "10.10.10.51"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 2
+  running_state     = "configured"
+  virtual_disk_size = 83
+}
+`, tenantTestImage())
+}
+
+func testAccTenantDeployTC4ResourceConfigFunc() string {
+	return fmt.Sprintf(`
+resource "f5os_tenant" "test2" {
+  name              = "testtenant-ecosys2"
+  image_name        = %q
+  mgmt_ip           = "10.10.10.27"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 2
+  running_state     = "configured"
+  virtual_disk_size = 83
+}
+`, tenantTestImage())
+}
+
+// --- Unit test configs (keep hardcoded image for mock server) ---
+
 const testAccTenantDeployResourceConfig = `
 resource "f5os_tenant" "test2" {
   name              = "testtenant-ecosys2"
@@ -337,21 +989,6 @@ resource "f5os_tenant" "test2" {
 `
 
 const testAccTenantDeployResourceConfigModify = `
-resource "f5os_tenant" "test2" {
-  name              = "testtenant-ecosys2"
-  image_name        = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
-  mgmt_ip           = "10.10.10.27"
-  mgmt_gateway      = "10.10.10.1"
-  mgmt_prefix       = 24
-  type              = "BIG-IP"
-  cpu_cores         = 8
-  running_state     = "configured"
-  virtual_disk_size = 82
-  vlans             = [ 1 ]
-}
-`
-
-const testAccTenantDeployTC4ResourceConfig = `
 resource "f5os_tenant" "test2" {
   name              = "testtenant-ecosys2"
   image_name        = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
@@ -408,29 +1045,107 @@ resource "f5os_tenant" "test-tenant22" {
 //  type              = "BIG-IP"
 //  cpu_cores         = 8
 //  running_state     = "configured"
-//  virtual_disk_size = 82
+//  virtual_disk_size = 83
 //  nodes             = [1]
 //  cryptos           = "enabled"
 //  vlans             = [1,2,3]
 //}
 //`
 
-const testAccTenantDeployTC5 = `
-resource "f5os_tenant" "velos_bigip_next_tenant_tc5" {
-	cpu_cores       = 4
-	cryptos         = "enabled"
-	deployment_file = "BIG-IP-Next-20.0.1-2.123.17.yaml"
-	image_name = "BIG-IP-Next-20.0.1-2.123.17"
-	mgmt_gateway           = "100.10.100.1"
-	mgmt_ip                = "100.10.100.110"
-	mgmt_prefix            = 24
-	dag_ipv6_prefix_length = 100
-	mac_block_size         = "medium"
-	name                   = "testtenant-ecosys03"
-	nodes                  = [2]
-	running_state          = "configured"
-	timeout           = 600
-	type              = "BIG-IP-Next"
-	virtual_disk_size = 30
-  }
+const testAccTenantVlansMultiConfig = `
+resource "f5os_tenant" "test2" {
+  name              = "testtenant-ecosys2"
+  image_name        = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
+  mgmt_ip           = "10.10.10.26"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 8
+  running_state     = "configured"
+  virtual_disk_size = 82
+  vlans             = [10, 20, 30]
+}
 `
+
+const testAccTenantNoVlansConfig = `
+resource "f5os_tenant" "test2" {
+  name              = "testtenant-ecosys2"
+  image_name        = "BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle"
+  mgmt_ip           = "10.10.10.26"
+  mgmt_gateway      = "10.10.10.1"
+  mgmt_prefix       = 24
+  type              = "BIG-IP"
+  cpu_cores         = 8
+  running_state     = "configured"
+  virtual_disk_size = 82
+}
+`
+
+// TestUnitTenantDeploymentFileNullForBigIP verifies that for a standard BIG-IP
+// tenant (no deployment_file in HCL or API response), the deployment_file
+// attribute is null in state (not unknown or empty string).
+func TestUnitTenantDeploymentFileNullForBigIP(t *testing.T) {
+	testAccPreUnitCheck(t)
+
+	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yang-data+json")
+		w.Header().Set("X-Auth-Token", "test-token")
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/f5os_auth.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-platform:components/component=platform/state/description", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/platform_state.json"))
+	})
+	mux.HandleFunc("/restconf/data/openconfig-vlan:vlans", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenant-images:images/image=BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"f5-tenant-images:image":[{"name":"BIGIP-17.1.0-0.0.16.ALL-F5OS.qcow2.zip.bundle","in-use":false,"type":"vm-image","status":"replicated","date":"2023-8-17","size":"2.27 GB"}]}`)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2/state", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_get_status.json"))
+	})
+	deleted := false
+	mux.HandleFunc("/restconf/data/f5-tenants:tenants/tenant=testtenant-ecosys2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "GET" && !deleted {
+			w.WriteHeader(http.StatusOK)
+			// Standard BIG-IP fixture — no deployment-file field
+			_, _ = fmt.Fprintf(w, "%s", loadFixtureString("./fixtures/tenant_config.json"))
+		} else if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value","error-message":"uri keypath not found"}]}}`)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantDeployResourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "name", "testtenant-ecosys2"),
+					resource.TestCheckResourceAttr("f5os_tenant.test2", "type", "BIG-IP"),
+					// deployment_file should not be present in state for BIG-IP tenants
+					resource.TestCheckNoResourceAttr("f5os_tenant.test2", "deployment_file"),
+				),
+			},
+		},
+	})
+}
+
+

--- a/internal/provider/vlan_resource_test.go
+++ b/internal/provider/vlan_resource_test.go
@@ -59,7 +59,7 @@ func TestAccVlanCreateTC2Resource(t *testing.T) {
 	})
 }
 
-func TestAccVlanCreateUnitTC1Resource(t *testing.T) {
+func TestUnitVlanCreateTC1Resource(t *testing.T) {
 	testAccPreUnitCheck(t)
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
@@ -114,7 +114,7 @@ func TestAccVlanCreateUnitTC1Resource(t *testing.T) {
 	})
 }
 
-func TestAccVlanCreateUnitTC2Resource(t *testing.T) {
+func TestUnitVlanCreateTC2Resource(t *testing.T) {
 	testAccPreUnitCheck(t)
 	var count = 0
 	mux.HandleFunc("/restconf/data/openconfig-system:system/aaa", func(w http.ResponseWriter, r *http.Request) {

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/doc.go
@@ -1,0 +1,2 @@
+// Package boolplanmodifier provides plan modifiers for types.Bool attributes.
+package boolplanmodifier

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace.go
@@ -1,0 +1,27 @@
+package boolplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplace returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//
+// Use RequiresReplaceIfConfigured if the resource replacement should
+// only occur if there is a configuration value (ignore unconfigured drift
+// detection changes). Use RequiresReplaceIf if the resource replacement
+// should check provider-defined conditional logic.
+func RequiresReplace() planmodifier.Bool {
+	return RequiresReplaceIf(
+		func(_ context.Context, _ planmodifier.BoolRequest, resp *RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace_if.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace_if.go
@@ -1,0 +1,70 @@
+package boolplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIf returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+//
+// Use RequiresReplace if the resource replacement should always occur on value
+// changes. Use RequiresReplaceIfConfigured if the resource replacement should
+// occur on value changes, but only if there is a configuration value (ignore
+// unconfigured drift detection changes).
+func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) planmodifier.Bool {
+	return requiresReplaceIfModifier{
+		ifFunc:              f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// requiresReplaceIfModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type requiresReplaceIfModifier struct {
+	ifFunc              RequiresReplaceIfFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyBool implements the plan modification logic.
+func (m requiresReplaceIfModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	ifFuncResp := &RequiresReplaceIfFuncResponse{}
+
+	m.ifFunc(ctx, req, ifFuncResp)
+
+	resp.Diagnostics.Append(ifFuncResp.Diagnostics...)
+	resp.RequiresReplace = ifFuncResp.RequiresReplace
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace_if_configured.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace_if_configured.go
@@ -1,0 +1,31 @@
+package boolplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfConfigured returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The configuration value is not null.
+//
+// Use RequiresReplace if the resource replacement should occur regardless of
+// the presence of a configuration value. Use RequiresReplaceIf if the resource
+// replacement should check provider-defined conditional logic.
+func RequiresReplaceIfConfigured() planmodifier.Bool {
+	return RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.BoolRequest, resp *RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace_if_func.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/requires_replace_if_func.go
@@ -1,0 +1,22 @@
+package boolplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type RequiresReplaceIfFunc func(context.Context, planmodifier.BoolRequest, *RequiresReplaceIfFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type RequiresReplaceIfFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// RequiresReplace should be enabled if the resource should be replaced.
+	RequiresReplace bool
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/use_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier/use_state_for_unknown.go
@@ -1,0 +1,52 @@
+package boolplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseStateForUnknown returns a plan modifier that copies a known prior state
+// value into the planned value. Use this when it is known that an unconfigured
+// value will remain the same after a resource update.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+func UseStateForUnknown() planmodifier.Bool {
+	return useStateForUnknownModifier{}
+}
+
+// useStateForUnknownModifier implements the plan modifier.
+type useStateForUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyBool implements the plan modification logic.
+func (m useStateForUnknownModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/doc.go
@@ -1,0 +1,2 @@
+// Package int64planmodifier provides plan modifiers for types.Int64 attributes.
+package int64planmodifier

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace.go
@@ -1,0 +1,27 @@
+package int64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplace returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//
+// Use RequiresReplaceIfConfigured if the resource replacement should
+// only occur if there is a configuration value (ignore unconfigured drift
+// detection changes). Use RequiresReplaceIf if the resource replacement
+// should check provider-defined conditional logic.
+func RequiresReplace() planmodifier.Int64 {
+	return RequiresReplaceIf(
+		func(_ context.Context, _ planmodifier.Int64Request, resp *RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace_if.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace_if.go
@@ -1,0 +1,70 @@
+package int64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIf returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+//
+// Use RequiresReplace if the resource replacement should always occur on value
+// changes. Use RequiresReplaceIfConfigured if the resource replacement should
+// occur on value changes, but only if there is a configuration value (ignore
+// unconfigured drift detection changes).
+func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) planmodifier.Int64 {
+	return requiresReplaceIfModifier{
+		ifFunc:              f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// requiresReplaceIfModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type requiresReplaceIfModifier struct {
+	ifFunc              RequiresReplaceIfFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyInt64 implements the plan modification logic.
+func (m requiresReplaceIfModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	ifFuncResp := &RequiresReplaceIfFuncResponse{}
+
+	m.ifFunc(ctx, req, ifFuncResp)
+
+	resp.Diagnostics.Append(ifFuncResp.Diagnostics...)
+	resp.RequiresReplace = ifFuncResp.RequiresReplace
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace_if_configured.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace_if_configured.go
@@ -1,0 +1,31 @@
+package int64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfConfigured returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The configuration value is not null.
+//
+// Use RequiresReplace if the resource replacement should occur regardless of
+// the presence of a configuration value. Use RequiresReplaceIf if the resource
+// replacement should check provider-defined conditional logic.
+func RequiresReplaceIfConfigured() planmodifier.Int64 {
+	return RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.Int64Request, resp *RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace_if_func.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/requires_replace_if_func.go
@@ -1,0 +1,22 @@
+package int64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type RequiresReplaceIfFunc func(context.Context, planmodifier.Int64Request, *RequiresReplaceIfFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type RequiresReplaceIfFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// RequiresReplace should be enabled if the resource should be replaced.
+	RequiresReplace bool
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -1,0 +1,52 @@
+package int64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseStateForUnknown returns a plan modifier that copies a known prior state
+// value into the planned value. Use this when it is known that an unconfigured
+// value will remain the same after a resource update.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+func UseStateForUnknown() planmodifier.Int64 {
+	return useStateForUnknownModifier{}
+}
+
+// useStateForUnknownModifier implements the plan modifier.
+type useStateForUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyInt64 implements the plan modification logic.
+func (m useStateForUnknownModifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/f5os.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/f5os.go
@@ -85,7 +85,23 @@ type F5os struct {
 	Password         string
 	DisableSSLVerify bool
 	Port             int
+	// PollInterval controls how long the client sleeps between polling
+	// iterations when waiting for asynchronous operations (image import,
+	// tenant deploy, partition creation, etc.). The zero value is treated
+	// as the production default of 20 seconds. Set to a short duration
+	// (e.g. 1ms) in unit tests to avoid slow test suites.
+	PollInterval time.Duration
 }
+
+// pollInterval returns the PollInterval if set, otherwise returns the
+// provided default duration.
+func (p *F5os) pollInterval(defaultInterval time.Duration) time.Duration {
+	if p.PollInterval > 0 {
+		return p.PollInterval
+	}
+	return defaultInterval
+}
+
 type requestError struct {
 	ErrorType    string `json:"error-type,omitempty"`
 	ErrorTag     string `json:"error-tag,omitempty"`
@@ -257,6 +273,15 @@ func NewSession(f5osObj *F5osConfig) (*F5os, error) {
 	}
 	f5osSession.Token = res.Header.Get("X-Auth-Token")
 	f5osSession.setPlatformType()
+
+	// Allow tests to override the poll interval via an environment variable
+	// so that unit tests with mock servers don't waste time sleeping.
+	if envPoll := os.Getenv("F5OS_POLL_INTERVAL"); envPoll != "" {
+		if d, err := time.ParseDuration(envPoll); err == nil {
+			f5osSession.PollInterval = d
+		}
+	}
+
 	f5osLogger.Info("[NewSession] Session creation Success")
 	return f5osSession, nil
 }
@@ -284,7 +309,7 @@ func (p *F5os) doRequest(op, path string, body []byte) ([]byte, error) {
 	}
 
 	retries := 3
-	delay := 10 * time.Second
+	delay := p.pollInterval(10 * time.Second)
 	for i := 0; i < retries; i++ {
 
 		req, err := http.NewRequest(op, path, bytes.NewBuffer(body))
@@ -974,7 +999,7 @@ func (p *F5os) CreateConfigBackup(backupName string, timeout int64, exportCfg Fi
 
 	f5osLogger.Debug("[CreateConfigBackup]", "transferId and key are ", hclog.Fmt("%+v, %+v", transferId, key))
 	waitTime := time.Second * time.Duration(timeout)
-	for start := time.Now(); time.Since(start).Seconds() < waitTime.Seconds(); time.Sleep(5 * time.Second) {
+	for start := time.Now(); time.Since(start).Seconds() < waitTime.Seconds(); time.Sleep(p.pollInterval(5 * time.Second)) {
 		status, err := p.fileTransferStatus(key, transferId)
 		if err != nil {
 			return nil, err

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/partition.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/partition.go
@@ -152,10 +152,10 @@ func (p *F5os) CheckPartitionState(partitionName string, timeOut int) ([]byte, e
 			return []byte(""), fmt.Errorf("partition deployment still in in progress with timeout period, please increase timeout")
 		}
 		if check {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			continue
 		} else {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			return []byte("Partition Deployment Success."), nil
 		}
 	}
@@ -390,9 +390,16 @@ func (p *F5os) DeleteTlsCertKey(certKeyName string) error {
 
 // PatchDNSConfig sets DNS config using PATCH to /system/dns
 func (c *F5os) PatchDNSConfig(dnsServers []string, searchDomains []string) error {
-	var servers []DNSServer
+	// Pre-allocate so json.Marshal produces "server":[] not "server":null
+	// when dnsServers is empty.
+	servers := make([]DNSServer, 0, len(dnsServers))
 	for _, s := range dnsServers {
 		servers = append(servers, DNSServer{Address: s})
+	}
+
+	// Ensure non-nil so json.Marshal produces "search":[] not "search":null
+	if searchDomains == nil {
+		searchDomains = []string{}
 	}
 
 	payload := DNSConfigPayload{
@@ -447,6 +454,12 @@ func (c *F5os) ReadDNSConfig() (*DNSConfigPayload, error) {
 	resp, err := c.GetRequest(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GET DNS config: %w", err)
+	}
+
+	// When no DNS config exists on the device, the API may return an
+	// empty body. Return an empty struct so callers can proceed.
+	if len(resp) == 0 {
+		return &DNSConfigPayload{}, nil
 	}
 
 	var config DNSConfigPayload
@@ -521,9 +534,9 @@ const (
 
 type ntpServerConfig struct {
 	Address string `json:"address"`
-	KeyID   int64  `json:"f5-openconfig-system-ntp:key-id,omitempty"`
-	Prefer  bool   `json:"prefer,omitempty"`
-	Iburst  bool   `json:"iburst,omitempty"`
+	KeyID   *int64 `json:"f5-openconfig-system-ntp:key-id,omitempty"`
+	Prefer  bool   `json:"prefer"`
+	Iburst  bool   `json:"iburst"`
 }
 
 type ntpServerPayload struct {
@@ -553,6 +566,18 @@ func (c *F5os) CreateNTPServer(server string, payload []byte) error {
 }
 
 func (c *F5os) CreateNTPServerPayload(server string, plan NTPServerModel) ([]byte, error) {
+	cfg := ntpServerConfig{
+		Address: server,
+		Prefer:  plan.Prefer.ValueBool(),
+		Iburst:  plan.IBurst.ValueBool(),
+	}
+	// Only include key-id when explicitly set (not null/unknown) so that
+	// omitempty correctly omits the field when the user did not configure it,
+	// while still sending key_id=0 when the user explicitly sets it to zero.
+	if !plan.KeyID.IsNull() && !plan.KeyID.IsUnknown() {
+		v := plan.KeyID.ValueInt64()
+		cfg.KeyID = &v
+	}
 	payload := ntpServerPayload{
 		Server: []struct {
 			Address string          `json:"address"`
@@ -560,12 +585,7 @@ func (c *F5os) CreateNTPServerPayload(server string, plan NTPServerModel) ([]byt
 		}{
 			{
 				Address: server,
-				Config: ntpServerConfig{
-					Address: server,
-					KeyID:   plan.KeyID.ValueInt64(),
-					Prefer:  plan.Prefer.ValueBool(),
-					Iburst:  plan.IBurst.ValueBool(),
-				},
+				Config:  cfg,
 			},
 		},
 	}
@@ -578,11 +598,64 @@ func (c *F5os) GetNTPServer(server string) (*NTPServerStruct, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GET NTP server failed: %w", err)
 	}
-	var ntpResp NTPServerStruct
-	if err := json.Unmarshal(resp, &ntpResp); err != nil {
+
+	var envelope ntpServerResponse
+	if err := json.Unmarshal(resp, &envelope); err != nil {
 		return nil, fmt.Errorf("invalid JSON for NTP server: %w", err)
 	}
-	return &ntpResp, nil
+	if len(envelope.Server) == 0 {
+		return nil, fmt.Errorf("NTP server %s not found in response", server)
+	}
+
+	entry := envelope.Server[0]
+	return &NTPServerStruct{
+		Address: entry.Config.Address,
+		KeyID:   entry.Config.KeyID,
+		Prefer:  entry.Config.Prefer,
+		IBurst:  entry.Config.IBurst,
+	}, nil
+}
+
+// GetNTPGlobalConfig reads the global NTP service and authentication settings
+// from /openconfig-system:system/ntp/config.
+func (c *F5os) GetNTPGlobalConfig() (service bool, auth bool, err error) {
+	resp, err := c.GetRequest(uriNTPConfigPatch)
+	if err != nil {
+		return false, false, fmt.Errorf("GET NTP global config failed: %w", err)
+	}
+
+	var envelope ntpGlobalConfigResponse
+	if err := json.Unmarshal(resp, &envelope); err != nil {
+		return false, false, fmt.Errorf("invalid JSON for NTP global config: %w", err)
+	}
+	return envelope.Config.Enabled, envelope.Config.EnableNTPAuth, nil
+}
+
+// UpdateNTPServerPayload builds a PATCH-appropriate payload for an individual
+// NTP server endpoint. Unlike CreateNTPServerPayload (which builds a POST
+// collection-level payload with "server":[...]), this wraps the entry in
+// "openconfig-system:server":[...] which is what PATCH on
+// /ntp/servers/server={addr} expects.
+func (c *F5os) UpdateNTPServerPayload(server string, plan NTPServerModel) ([]byte, error) {
+	cfg := ntpServerConfig{
+		Address: server,
+		Prefer:  plan.Prefer.ValueBool(),
+		Iburst:  plan.IBurst.ValueBool(),
+	}
+	if !plan.KeyID.IsNull() && !plan.KeyID.IsUnknown() {
+		v := plan.KeyID.ValueInt64()
+		cfg.KeyID = &v
+	}
+	// PATCH on /server={addr} expects "openconfig-system:server" key
+	payload := map[string]interface{}{
+		"openconfig-system:server": []map[string]interface{}{
+			{
+				"address": server,
+				"config":  cfg,
+			},
+		},
+	}
+	return json.Marshal(payload)
 }
 
 func (c *F5os) UpdateNTPServer(server string, payload []byte) error {
@@ -771,7 +844,7 @@ func (c *F5os) UpdateSnmpMib(payload []byte) error {
 	return nil
 }
 
-// SNMP Read method
+// SNMP Read methods
 func (c *F5os) GetSnmpConfig() ([]byte, error) {
 	resp, err := c.GetRequest(uriSnmpBase)
 	if err != nil {
@@ -780,13 +853,23 @@ func (c *F5os) GetSnmpConfig() ([]byte, error) {
 	return resp, nil
 }
 
+func (c *F5os) GetSnmpMib() ([]byte, error) {
+	resp, err := c.GetRequest(uriSnmpMib)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SNMP MIB: %w", err)
+	}
+	return resp, nil
+}
+
 // Auth/AAA related constants and methods
 const (
-	uriAAA           = "/openconfig-system:system/aaa/authentication"
-	uriAAAConfig     = "/openconfig-system:system/aaa/authentication/config"
-	uriAAAAuthMethod = "/openconfig-system:system/aaa/authentication/config/authentication-method"
-	uriAAARoles      = "/openconfig-system:system/aaa/authentication/f5-system-aaa:roles"
-	uriAAARoleConfig = "/openconfig-system:system/aaa/authentication/f5-system-aaa:roles/f5-system-aaa:role=%s/f5-system-aaa:config"
+	uriAAA               = "/openconfig-system:system/aaa/authentication"
+	uriAAAConfig         = "/openconfig-system:system/aaa/authentication/config"
+	uriAAAAuthMethod     = "/openconfig-system:system/aaa/authentication/config/authentication-method"
+	uriAAARoles          = "/openconfig-system:system/aaa/authentication/f5-system-aaa:roles"
+	uriAAARoleConfig     = "/openconfig-system:system/aaa/authentication/f5-system-aaa:roles/f5-system-aaa:role=%s/f5-system-aaa:config"
+	uriAAARoleRemoteGID  = "/openconfig-system:system/aaa/authentication/f5-system-aaa:roles/f5-system-aaa:role=%s/f5-system-aaa:config/f5-system-aaa:remote-gid"
+	uriAAAPasswordPolicy = "/openconfig-system:system/aaa/f5-openconfig-aaa-password-policy:password-policy/config"
 )
 
 type authOrderPayload struct {
@@ -797,7 +880,7 @@ type authOrderPayload struct {
 
 type authRoleConfig struct {
 	Rolename string `json:"f5-system-aaa:rolename"`
-	GID      *int64 `json:"f5-system-aaa:gid,omitempty"`
+	GID      *int64 `json:"f5-system-aaa:remote-gid,omitempty"`
 }
 
 type authRolePayload struct {
@@ -900,14 +983,26 @@ func (c *F5os) SetRoleConfig(rolename string, gid *int64) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal role config payload: %w", err)
 	}
-	_, err = c.PutRequest(uri, body)
+	_, err = c.PatchRequest(uri, body)
 	if err != nil {
-		return fmt.Errorf("PUT role config failed: %w", err)
+		return fmt.Errorf("PATCH role config failed: %w", err)
 	}
 	return nil
 }
 
-// GetRoles returns map[rolename]gid
+// ClearRoleRemoteGID deletes the remote-gid leaf for a role, returning it
+// to the device default (unset / "-").
+func (c *F5os) ClearRoleRemoteGID(rolename string) error {
+	uri := fmt.Sprintf(uriAAARoleRemoteGID, rolename)
+	err := c.DeleteRequest(uri)
+	if err != nil {
+		return fmt.Errorf("DELETE role remote-gid failed: %w", err)
+	}
+	return nil
+}
+
+// GetRoles returns map[rolename]remote-gid for all roles on the device.
+// Roles without a remote-gid configured will have a value of 0.
 func (c *F5os) GetRoles() (map[string]int, error) {
 	resp, err := c.GetRequest(uriAAARoles)
 	if err != nil {
@@ -939,9 +1034,15 @@ func (c *F5os) GetRoles() (map[string]int, error) {
 			}
 			if configRaw, ok := roleMap["config"]; ok {
 				if configMap, ok := configRaw.(map[string]any); ok {
-					if gidRaw, ok := configMap["gid"]; ok {
-						if gidFloat, ok := gidRaw.(float64); ok {
-							gid = int(gidFloat)
+					// Read remote-gid, the group ID used for remote
+					// authentication mapping. This is distinct from gid
+					// (the built-in system group ID for the role).
+					// Roles without a remote-gid configured return "-"
+					// (a string), which won't parse as float64, so gid
+					// stays at the zero value.
+					if rgidRaw, ok := configMap["remote-gid"]; ok {
+						if rgidFloat, ok := rgidRaw.(float64); ok {
+							gid = int(rgidFloat)
 						}
 					}
 				}
@@ -952,4 +1053,68 @@ func (c *F5os) GetRoles() (map[string]int, error) {
 		}
 	}
 	return result, nil
+}
+
+// PasswordPolicyConfig represents the password policy settings.
+// Pointer fields allow distinguishing "not set" from zero values.
+type PasswordPolicyConfig struct {
+	MinLength           *int64 `json:"min-length,omitempty"`
+	RequiredNumeric     *int64 `json:"required-numeric,omitempty"`
+	RequiredUppercase   *int64 `json:"required-uppercase,omitempty"`
+	RequiredLowercase   *int64 `json:"required-lowercase,omitempty"`
+	RequiredSpecial     *int64 `json:"required-special,omitempty"`
+	RequiredDifferences *int64 `json:"required-differences,omitempty"`
+	RejectUsername      *bool  `json:"reject-username,omitempty"`
+	ApplyToRoot         *bool  `json:"apply-to-root,omitempty"`
+	Retries             *int64 `json:"retries,omitempty"`
+	MaxLoginFailures    *int64 `json:"max-login-failures,omitempty"`
+	UnlockTime          *int64 `json:"unlock-time,omitempty"`
+	RootLockout         *bool  `json:"root-lockout,omitempty"`
+	RootUnlockTime      *int64 `json:"root-unlock-time,omitempty"`
+	MaxAge              *int64 `json:"max-age,omitempty"`
+	// v1.7+ only fields
+	MaxLetterRepeat   *int64 `json:"max-letter-repeat,omitempty"`
+	MaxSequenceRepeat *int64 `json:"max-sequence-repeat,omitempty"`
+	MaxClassRepeat    *int64 `json:"max-class-repeat,omitempty"`
+}
+
+// passwordPolicyResponse is the API response wrapper for password policy.
+type passwordPolicyResponse struct {
+	Config PasswordPolicyConfig `json:"f5-openconfig-aaa-password-policy:config"`
+}
+
+// passwordPolicyPayload is the API request wrapper for password policy.
+type passwordPolicyPayload struct {
+	Config PasswordPolicyConfig `json:"f5-openconfig-aaa-password-policy:config"`
+}
+
+// GetPasswordPolicy reads the current password policy config from the device.
+func (c *F5os) GetPasswordPolicy() (*PasswordPolicyConfig, error) {
+	resp, err := c.GetRequest(uriAAAPasswordPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("GET password policy failed: %w", err)
+	}
+
+	var parsed passwordPolicyResponse
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid JSON for password policy: %w", err)
+	}
+
+	return &parsed.Config, nil
+}
+
+// SetPasswordPolicy updates password policy config on the device using PATCH.
+// Only fields with non-nil values are sent.
+func (c *F5os) SetPasswordPolicy(config *PasswordPolicyConfig) error {
+	payload := passwordPolicyPayload{Config: *config}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal password policy payload: %w", err)
+	}
+
+	_, err = c.PatchRequest(uriAAAPasswordPolicy, body)
+	if err != nil {
+		return fmt.Errorf("PATCH password policy failed: %w", err)
+	}
+	return nil
 }

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/structs_partition.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/structs_partition.go
@@ -570,9 +570,9 @@ type PrimaryKeyConfig struct {
 type F5RespPrimaryKey struct {
 	PrimaryKey struct {
 		State struct {
-			Hash   string `json:"f5-primary-key:hash"`
-			Status string `json:"f5-primary-key:status"`
-		} `json:"f5-primary-key:state"`
+			Hash   string `json:"hash"`
+			Status string `json:"status"`
+		} `json:"state"`
 	} `json:"f5-primary-key:primary-key"`
 }
 
@@ -606,13 +606,63 @@ type NTPServerModel struct {
 	NTPAuthentication types.Bool   `tfsdk:"ntp_authentication"`
 }
 
-// NTPServerStruct is the internal Go representation
-// used for HTTP payloads and response parsing.
+// ntpServerResponse models the RESTCONF JSON returned by
+// GET /openconfig-system:system/ntp/openconfig-system:servers/server={addr}
+//
+//	{
+//	  "openconfig-system:server": [{
+//	    "address": "10.20.30.40",
+//	    "config": {
+//	      "address":                          "10.20.30.40",
+//	      "f5-openconfig-system-ntp:key-id":  123,
+//	      "prefer":                           true,
+//	      "iburst":                           true
+//	    }
+//	  }]
+//	}
+type ntpServerResponse struct {
+	Server []ntpServerEntry `json:"openconfig-system:server"`
+}
+
+type ntpServerEntry struct {
+	Address string              `json:"address"`
+	Config  ntpServerReadConfig `json:"config"`
+}
+
+type ntpServerReadConfig struct {
+	Address string `json:"address"`
+	KeyID   *int64 `json:"f5-openconfig-system-ntp:key-id,omitempty"`
+	Prefer  bool   `json:"prefer,omitempty"`
+	IBurst  bool   `json:"iburst,omitempty"`
+}
+
+// ntpGlobalConfigResponse models the RESTCONF JSON returned by
+// GET /openconfig-system:system/ntp/config
+//
+//	{
+//	  "openconfig-system:config": {
+//	    "enabled":        true,
+//	    "enable-ntp-auth": true
+//	  }
+//	}
+type ntpGlobalConfigResponse struct {
+	Config ntpGlobalConfigFields `json:"openconfig-system:config"`
+}
+
+type ntpGlobalConfigFields struct {
+	Enabled       bool `json:"enabled,omitempty"`
+	EnableNTPAuth bool `json:"enable-ntp-auth,omitempty"`
+}
+
+// NTPServerStruct is the flattened Go representation returned by
+// GetNTPServer + GetNTPGlobalConfig for the provider Read method.
+// KeyID is a pointer so callers can distinguish "device returned 0"
+// from "device did not return key_id at all".
 type NTPServerStruct struct {
-	Address           string `json:"address"`
-	KeyID             int64  `json:"key_id,omitempty"`
-	Prefer            bool   `json:"prefer,omitempty"`
-	IBurst            bool   `json:"iburst,omitempty"`
-	NTPService        bool   `json:"ntp_service,omitempty"`
-	NTPAuthentication bool   `json:"ntp_authentication,omitempty"`
+	Address           string
+	KeyID             *int64
+	Prefer            bool
+	IBurst            bool
+	NTPService        bool
+	NTPAuthentication bool
 }

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/structs_tenant.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/structs_tenant.go
@@ -44,10 +44,17 @@ type F5RespTenantImagesStatus struct {
 }
 
 type F5ReqTenantImage struct {
-	Insecure   string `json:"insecure"`
-	LocalFile  string `json:"local-file,omitempty"`
-	RemoteFile string `json:"remote-file,omitempty"`
-	RemoteHost string `json:"remote-host,omitempty"`
+	// Insecure represents a YANG empty leaf.  Per RFC 7951 the JSON
+	// encoding of an empty leaf is [null].  Set to []interface{}{nil}
+	// to enable insecure mode; leave nil to omit the field.
+	Insecure   interface{} `json:"insecure,omitempty"`
+	LocalFile  string      `json:"local-file,omitempty"`
+	RemoteFile string      `json:"remote-file,omitempty"`
+	RemoteHost string      `json:"remote-host,omitempty"`
+	Protocol   string      `json:"protocol,omitempty"`
+	Username   string      `json:"username,omitempty"`
+	Password   string      `json:"password,omitempty"`
+	RemotePort int         `json:"remote-port,omitempty"`
 }
 type F5ReqTenant struct {
 	Name           string `json:"name,omitempty"`

--- a/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/tenant.go
+++ b/vendor/gitswarm.f5net.com/terraform-providers/f5osclient/tenant.go
@@ -133,7 +133,7 @@ func (p *F5os) UploadImage(filePath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	time.Sleep(time.Second * 10)
+	time.Sleep(p.pollInterval(10 * time.Second))
 	return resp, nil
 }
 
@@ -165,7 +165,7 @@ func (p *F5os) getUploadId(fileObj *os.File) (string, error) {
 }
 
 func (p *F5os) ImportImage(tenantImage *F5ReqTenantImage, timeOut int) ([]byte, error) {
-	f5osLogger.Debug("[ImportImage]", "Image struct:", hclog.Fmt("%+v", tenantImage))
+	f5osLogger.Debug("[ImportImage]", "RemoteHost:", tenantImage.RemoteHost, "RemoteFile:", tenantImage.RemoteFile, "LocalFile:", tenantImage.LocalFile, "Protocol:", tenantImage.Protocol, "Username:", tenantImage.Username)
 	byteBody, err := json.Marshal(tenantImage)
 	if err != nil {
 		return byteBody, err
@@ -179,9 +179,15 @@ func (p *F5os) ImportImage(tenantImage *F5ReqTenantImage, timeOut int) ([]byte, 
 		return []byte(""), fmt.Errorf("%s", string(respData))
 	}
 
+	// Parse the operation-id from the import response so importWait can
+	// match on the exact transfer operation instead of the remote-file-path
+	// (which may collide with historical entries in the transfer list).
+	operationID := parseImportOperationID(respData)
+	f5osLogger.Info("[ImportImage]", "Operation ID: ", hclog.Fmt("%+v", operationID))
+
 	t1 := time.Now()
 	for {
-		check, err := p.importWait(tenantImage)
+		check, err := p.importWait(tenantImage, operationID)
 		if err != nil {
 			return []byte(""), err
 		}
@@ -191,42 +197,97 @@ func (p *F5os) ImportImage(tenantImage *F5ReqTenantImage, timeOut int) ([]byte, 
 			return []byte(""), fmt.Errorf("image Import transfer still in In Progress with Timeout Period, please increase timeout")
 		}
 		if check {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			continue
 		} else {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			return []byte("Import Image Transfer Success"), nil
 		}
 	}
 }
 
-func (p *F5os) importWait(tenantImage *F5ReqTenantImage) (bool, error) {
+// parseImportOperationID extracts the operation-id from the import POST
+// response JSON.  The expected format is:
+//
+//	{"f5-utils-file-transfer:output": {"result": "...", "operation-id": "IMPORT-xxxx"}}
+//
+// Returns an empty string if the ID cannot be parsed (older firmware may
+// not include it).
+func parseImportOperationID(respData []byte) string {
+	var envelope struct {
+		Output struct {
+			OperationID string `json:"operation-id"`
+		} `json:"f5-utils-file-transfer:output"`
+	}
+	if err := json.Unmarshal(respData, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Output.OperationID
+}
+
+// importWait polls the transfer-operation list for the status of the import
+// identified by operationID.  If operationID is non-empty it matches on that
+// field for an exact 1:1 match; otherwise it falls back to matching on
+// remote-file-path (legacy behaviour for older firmware that does not return
+// an operation-id).
+func (p *F5os) importWait(tenantImage *F5ReqTenantImage, operationID string) (bool, error) {
 	transferMap, err := p.getImporttransferStatus()
-	for _, val := range transferMap["f5-utils-file-transfer:transfer-operation"].([]interface{}) {
-		if val.(map[string]interface{})["remote-file-path"].(string) != tenantImage.RemoteFile {
+	if err != nil {
+		return true, nil
+	}
+	if transferMap == nil {
+		return true, nil
+	}
+
+	ops, ok := transferMap["f5-utils-file-transfer:transfer-operation"].([]interface{})
+	if !ok || ops == nil {
+		return true, nil
+	}
+
+	for _, val := range ops {
+		entry, ok := val.(map[string]interface{})
+		if !ok {
 			continue
 		}
-		transStatus := val.(map[string]interface{})["status"].(string)
+
+		// Match by operation-id when available; fall back to remote-file-path.
+		if operationID != "" {
+			entryID, _ := entry["operation-id"].(string)
+			if entryID != operationID {
+				continue
+			}
+		} else {
+			remotePath, _ := entry["remote-file-path"].(string)
+			if remotePath != tenantImage.RemoteFile {
+				continue
+			}
+		}
+
+		transStatus, _ := entry["status"].(string)
 		f5osLogger.Info("[importWait]", "Trans Status: ", hclog.Fmt("%+v", transStatus))
-		if err != nil {
+
+		// Known in-progress statuses — keep polling.
+		if strings.HasPrefix(transStatus, "In Progress") || strings.Contains(transStatus, "File Transfer Initiated") {
 			return true, nil
 		}
+
+		// Completed — transfer succeeded.
 		if strings.Contains(transStatus, "Completed") {
 			return false, nil
 		}
-		if strings.Contains(transStatus, "HTTP Error") {
+
+		// Any other non-empty status is treated as a terminal error.
+		// This avoids silent infinite polling if the F5OS API introduces
+		// new error statuses in the future.
+		if transStatus != "" {
 			return false, fmt.Errorf("%s", transStatus)
 		}
-		if strings.Contains(transStatus, "Couldn't resolve host") {
-			return false, fmt.Errorf("%s", transStatus)
-		}
-		if strings.Contains(transStatus, "Failure") {
-			return false, fmt.Errorf("%s", transStatus)
-		}
-		for strings.HasPrefix(transStatus, "In Progress") {
-			return true, nil
-		}
+
+		// Empty status — entry exists but hasn't been populated yet;
+		// keep polling.
+		return true, nil
 	}
+	// No matching entry found yet — keep polling.
 	return true, nil
 }
 
@@ -331,7 +392,7 @@ func (p *F5os) CreateTenantAndGetApi(tenantObj *F5ReqTenants, timeOut int) ([]by
 		for {
 			resp, err := p.GetApi()
 			f5osLogger.Info("[CreateTenantAndGetApi]", "RequestGetApi ", hclog.Fmt("%+v", string(resp)))
-			time.Sleep(15 * time.Second)
+			time.Sleep(p.pollInterval(15 * time.Second))
 			chan2 <- resp
 			err2 <- err
 		}
@@ -365,7 +426,7 @@ func (p *F5os) CreateTenant(tenantObj *F5ReqTenants, timeOut int) ([]byte, error
 		check, err := p.tenantWait(tenantObj.F5TenantsTenant[0].Name, tenantObj.F5TenantsTenant[0].Config.RunningState)
 		if err != nil {
 			if err.Error() == "tenant status not found" {
-				time.Sleep(30 * time.Second)
+				time.Sleep(p.pollInterval(30 * time.Second))
 				t1 = time.Now()
 				continue
 			}
@@ -394,10 +455,10 @@ func (p *F5os) CreateTenant(tenantObj *F5ReqTenants, timeOut int) ([]byte, error
 			//return []byte(""), fmt.Errorf("[TF-100]tenant deployment still in In Progress with in Timeout Period, please increase timeout")
 		}
 		if check {
-			time.Sleep(80 * time.Second)
+			time.Sleep(p.pollInterval(80 * time.Second))
 			continue
 		} else {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			// stop <- true
 			return []byte("Tenant Deployment Success"), nil
 		}
@@ -425,7 +486,7 @@ func (p *F5os) UpdateTenant(tenantObj *F5ReqTenantsPatch, timeOut int) ([]byte, 
 		check, err := p.tenantWait(tenantObj.F5TenantsTenants.Tenant[0].Name, tenantObj.F5TenantsTenants.Tenant[0].Config.RunningState)
 		if err != nil {
 			if err.Error() == "tenant status not found" {
-				time.Sleep(30 * time.Second)
+				time.Sleep(p.pollInterval(30 * time.Second))
 				t1 = time.Now()
 				continue
 			}
@@ -437,10 +498,10 @@ func (p *F5os) UpdateTenant(tenantObj *F5ReqTenantsPatch, timeOut int) ([]byte, 
 			return []byte(""), fmt.Errorf("tenant deployment still in In Progress with Timeout Period, please incraese timeout")
 		}
 		if check {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			continue
 		} else {
-			time.Sleep(20 * time.Second)
+			time.Sleep(p.pollInterval(20 * time.Second))
 			return []byte("Tenant Deployment Success"), nil
 		}
 	}
@@ -521,7 +582,7 @@ func (p *F5os) DeleteTenant(tenantName string) error {
 		return err
 	}
 	f5osLogger.Debug("[DeleteTenant]", "wait for 50 sec", hclog.Fmt("%d", 10))
-	time.Sleep(50 * time.Second)
+	time.Sleep(p.pollInterval(50 * time.Second))
 	p.CheckTenantnotexist(tenantName)
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,9 +141,11 @@ github.com/hashicorp/terraform-plugin-framework/providerserver
 github.com/hashicorp/terraform-plugin-framework/resource
 github.com/hashicorp/terraform-plugin-framework/resource/schema
 github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault
+github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults
 github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default
 github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault
+github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault
 github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier


### PR DESCRIPTION
## Release v1.11.1

### FEATURES
* `f5os_auth`: Added `password_policy` support for managing password policy configuration
* `schemadiff`: New tool to diff and report on schema changes between F5OS versions
* CI/CD: Added support for scheduled releases

### BUG FIXES (35)
* `f5os_system`: Only manage optional system settings that are explicitly configured; prevent panic on nil SshdIdleTimeout
* `f5os_dns`: Read method now refreshes state from device; delete preserves device config; stale entry cleanup on update; null domain/response handling
* `f5os_tenant`: Deployment file, type, and VLANs now properly mapped in Read/state refresh
* `f5os_tenant_image`: Fix panic on nil map, Read/Import state preservation, GetImage error handling, timeout calculation, conflict validators, insecure attribute, protocol/user/password/port properties
* `f5os_ntp_server`: Fix duplicate type definition, key_id=0 omitempty, import support, ntp_service/authentication write
* `f5os_primarykey`: Fix force_update=false skip logic, JSON deserialization, async migration refresh
* `f5os_user`: Role update removes stale assignments; fix role GID revert on delete
* `f5os_auth`: Fix import, SetRoleConfig, auth_order restore, role filtering, JSON parsing on 1.8.3
* `f5os_snmp`: Delete now properly resets MIB fields

### IMPROVEMENTS
* Added unit and acceptance tests for partition_change_password resource
* Added configurable PollInterval to f5osclient, reducing unit test runtime from ~24 minutes to ~7 minutes
* Documentation updates

### Pre-release test results
- Unit tests: 145 passed, 0 failed, 95 skipped