### PR TITLE
ci: pass GPG_PASSPHRASE to GoReleaser signing step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,4 @@ jobs:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
Fixes GoReleaser release failure: `.goreleaser.yml` references `{{ .Env.GPG_PASSPHRASE }}` for GPG signing but `release.yml` never set this env var for the GoReleaser step. Adds `GPG_PASSPHRASE: ${{ secrets.PASSPHRASE }}` to the env block.